### PR TITLE
Improvements

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -4,7 +4,8 @@
     ]},
 
     {mnesia, [
-        {dir, "/var/lib/dcos/navstar/mnesia"}
+        {dir, "/var/lib/dcos/navstar/mnesia"},
+        {dump_log_write_threshold, 10}
     ]},
 
     {dcos_rest, [

--- a/config/vm.args
+++ b/config/vm.args
@@ -29,5 +29,7 @@
 ## Scheduler modifications.
 -stbt nnts
 
+## Dirty I/O schedulers
++SDio 0
 
 # This file MUST have extra new lines at the end

--- a/config/vm.args
+++ b/config/vm.args
@@ -4,10 +4,6 @@
 ## Cookie for distributed erlang
 -setcookie minuteman
 
-## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
-## (Disabled by default..use with caution!)
-##-heart
-
 ## Enable kernel poll and a few async threads
 +K true
 +A 100
@@ -20,20 +16,18 @@
 
 +P 256000
 
+## Enable time correction
 +C multi_time_warp
 +c true
 
+## Disable a fully connected network for global module
 -connect_all false
 
 ## Increase atom count 4x
 +t 4194304
 
-# Scheduler modifications.
+## Scheduler modifications.
 -stbt nnts
 
-## Dirty schedulers and CPU
--smp enable
-## Dirty Scheduler count is 100% of CPUs, with only 50% online
-+SDPcpu 100:100
 
 # This file MUST have extra new lines at the end

--- a/config/vm.args
+++ b/config/vm.args
@@ -6,15 +6,16 @@
 
 ## Enable kernel poll and a few async threads
 +K true
-+A 100
++A 10
 
 ## Increase number of concurrent ports/sockets
--env ERL_MAX_PORTS 100000
+-env ERL_MAX_PORTS 16384
 
 ## Tweak GC to run more often
 ##-env ERL_FULLSWEEP_AFTER 10
 
-+P 256000
+## Maximum number of simultaneously existing processes
+##+P 262144
 
 ## Enable time correction
 +C multi_time_warp

--- a/config/vm.args
+++ b/config/vm.args
@@ -23,8 +23,6 @@
 +C multi_time_warp
 +c true
 
--epmd_port 61420
-
 -connect_all false
 
 ## Increase atom count 4x

--- a/rebar.config
+++ b/rebar.config
@@ -65,7 +65,8 @@
     {extended_start_script, true},
     {overlay, [
         {mkdir, "log/sasl"},
-        {mkdir, "data/"}
+        {mkdir, "data/"},
+        {copy, "apps/dcos_dns/data/zones.json", "data/zones.json"}
     ]}
 ]}.
 


### PR DESCRIPTION
* Speedup dcos-net startup time
* Reduce number of threads from 123 to 18
* Fix erldns error: `[error] Failed to load zones: enoent`
* Set dump_log_write_threshold to 10

We don't need 100 async threads and 100000 open files since we don't have so much i/o operations.