### PR TITLE
Downgrade OTP to 20.0.5

### DIFF
--- a/apps/dcos_dns/src/dcos_dns_app.erl
+++ b/apps/dcos_dns/src/dcos_dns_app.erl
@@ -31,7 +31,6 @@ maybe_start_dcos_dns(false) ->
 maybe_start_dcos_dns(true) ->
     Ret = dcos_dns_sup:start_link(true),
     maybe_start_tcp_listener(),
-    maybe_start_http_listener(),
     Ret.
 
 stop(_State) ->
@@ -113,34 +112,6 @@ start_tcp_listener(IP) ->
         Options,
         dcos_dns_tcp_handler,
         []).
-
--spec(maybe_start_http_listener() -> ok).
-maybe_start_http_listener() ->
-    case dcos_dns_config:http_enabled() of
-        true ->
-            start_http_listener({127, 0, 0, 1});
-        false ->
-            ok
-    end.
-
--spec(start_http_listener(inet:ip4_address()) -> supervisor:startchild_ret()).
-start_http_listener(IP) ->
-    Dispatch = cowboy_router:compile([
-        {'_', [
-            {"/v1/version", dcos_dns_http_handler, [version]},
-            {"/v1/config", dcos_dns_http_handler, [config]},
-            {"/v1/hosts/:host", dcos_dns_http_handler, [hosts]},
-            {"/v1/services/:service", dcos_dns_http_handler, [services]},
-            {"/v1/enumerate", dcos_dns_http_handler, [enumerate]},
-            {"/v1/records", dcos_dns_http_handler, [records]}
-        ]}
-    ]),
-    Port = dcos_dns_config:http_port(),
-    cowboy:start_http(
-        IP, 1024,
-        [dcos_dns:family(IP), {ip, IP}, {port, Port}],
-        [{env, [{dispatch, Dispatch}]}]
-    ).
 
 % Sample configuration:
 %  {

--- a/apps/dcos_dns/src/dcos_dns_config.erl
+++ b/apps/dcos_dns/src/dcos_dns_config.erl
@@ -16,7 +16,6 @@
     exhibitor_timeout/0,
     udp_enabled/0, udp_port/0,
     tcp_enabled/0, tcp_port/0,
-    http_enabled/0, http_port/0,
     bind_interface/0, bind_ips/0,
     forward_zones/0,
     handler_limit/0,
@@ -40,12 +39,6 @@ udp_port() ->
 
 handler_limit() ->
     application:get_env(?APP, handler_limit, 1024).
-
-http_enabled() ->
-    application:get_env(?APP, http_server_enabled, true).
-
-http_port() ->
-    application:get_env(?APP, http_port, 63053).
 
 -spec(forward_zones() -> #{[dns:label()] => [{string(), integer()}]}).
 forward_zones() ->

--- a/apps/dcos_dns/src/dcos_dns_router.erl
+++ b/apps/dcos_dns/src/dcos_dns_router.erl
@@ -10,42 +10,20 @@
 -export([upstreams_from_questions/1]).
 
 %% @doc Resolvers based on a set of "questions"
--spec(upstreams_from_questions(dns:questions()) -> ordsets:ordset(upstream())).
+-spec(upstreams_from_questions(dns:questions()) -> [upstream()] | erldns).
 upstreams_from_questions([#dns_query{name=Name}]) ->
     Labels = dcos_dns_app:parse_upstream_name(Name),
-    Upstreams = find_upstream(Labels),
-    lists:map(fun validate_upstream/1, Upstreams);
-
-%% There is more than one question. This is beyond our capabilities at the moment
+    find_upstream(Labels);
 upstreams_from_questions([Question|Others]) ->
+    %% There is more than one question. This is beyond our capabilities at the moment
     dcos_dns_metrics:update([dcos_dns, ignored_questions], length(Others), ?COUNTER),
-    upstreams_from_questions([Question]).
+    Result = upstreams_from_questions([Question]),
+    lager:debug("~p will be forwarded to ~p", [Others, Result]),
+    Result.
 
 -spec(validate_upstream(upstream()) -> upstream()).
 validate_upstream({{_, _, _, _}, Port} = Upstream) when is_integer(Port) ->
     Upstream.
-
-%% This one is a little bit more complicated...
-%% @private
--spec(erldns_resolvers() -> [upstream()]).
-erldns_resolvers() ->
-    ErlDNSServers = application:get_env(erldns, servers, []),
-    retrieve_servers(ErlDNSServers, []).
-retrieve_servers([], Acc) ->
-    Acc;
-retrieve_servers([Config|Rest], Acc) ->
-    case {
-            inet:parse_ipv4_address(proplists:get_value(address, Config, "")),
-            proplists:get_value(port, Config),
-            proplists:get_value(family, Config)
-    } of
-        {_, undefined, _} ->
-            retrieve_servers(Rest, Acc);
-        {{ok, Address}, Port, inet} when is_integer(Port) ->
-            retrieve_servers(Rest, [{Address, Port}|Acc]);
-        _ ->
-            retrieve_servers(Rest, Acc)
-    end.
 
 %% @private
 -spec(default_resolvers() -> [upstream()]).
@@ -55,24 +33,25 @@ default_resolvers() ->
                 {{8, 8, 8, 8}, 53},
                 {{4, 2, 2, 1}, 53},
                 {{8, 8, 8, 8}, 53}],
-    application:get_env(?APP, upstream_resolvers, Defaults).
+    Resolvers = application:get_env(?APP, upstream_resolvers, Defaults),
+    lists:map(fun validate_upstream/1, Resolvers).
 
 %% @private
--spec(find_upstream(Labels :: [binary()]) -> [upstream()]).
+-spec(find_upstream(Labels :: [binary()]) -> [upstream()] | erldns).
 find_upstream([<<"mesos">>|_]) ->
     dcos_dns_config:mesos_resolvers();
 find_upstream([<<"localhost">>|_]) ->
-    erldns_resolvers();
+    erldns;
 find_upstream([<<"zk">>|_]) ->
-    erldns_resolvers();
+    erldns;
 find_upstream([<<"spartan">>|_]) ->
-    erldns_resolvers();
+    erldns;
 find_upstream([<<"directory">>, <<"thisdcos">>|_]) ->
-    erldns_resolvers();
+    erldns;
 find_upstream([<<"global">>, <<"thisdcos">>|_]) ->
-    erldns_resolvers();
+    erldns;
 find_upstream([<<"directory">>, <<"dcos">>|_]) ->
-    erldns_resolvers();
+    erldns;
 find_upstream(Labels) ->
     case find_custom_upstream(Labels) of
         [] ->

--- a/apps/dcos_dns/test/dcos_dns_SUITE.erl
+++ b/apps/dcos_dns/test/dcos_dns_SUITE.erl
@@ -42,6 +42,7 @@ init_per_suite(_Config) ->
     ],
     meck_mods(Workers),
     {ok, _} = application:ensure_all_started(dcos_dns),
+    {ok, _} = application:ensure_all_started(dcos_rest),
     meck:unload(Workers),
     generate_fixture_mesos_zone(),
     generate_thisdcos_directory_zone(),
@@ -258,7 +259,7 @@ resolver_options() ->
     [{nameservers, [dcos_dns_app:parse_ipv4_address_with_port(LocalResolver, 53)]}].
 
 http_hosts_test(_Config) ->
-    Records = request("http://localhost:63053/v1/hosts/commontest.thisdcos.directory"),
+    Records = request("http://localhost:62080/v1/hosts/commontest.thisdcos.directory"),
     lists:foreach(fun (RR) ->
         ?assertMatch(
             {<<"host">>, <<"commontest.thisdcos.directory">>},
@@ -271,7 +272,7 @@ http_hosts_test(_Config) ->
     end, Records).
 
 http_services_test(_Config) ->
-    Records = request("http://localhost:63053/v1/services/_service._tcp.commontest.thisdcos.directory"),
+    Records = request("http://localhost:62080/v1/services/_service._tcp.commontest.thisdcos.directory"),
     lists:foreach(fun (RR) ->
         ?assertMatch(
             {<<"service">>, <<"_service._tcp.commontest.thisdcos.directory">>},
@@ -287,7 +288,7 @@ http_services_test(_Config) ->
     end, Records).
 
 http_records_test(_Config) ->
-    Records = request("http://localhost:63053/v1/records"),
+    Records = request("http://localhost:62080/v1/records"),
     Records0 =
         lists:filter(fun (RR) ->
             {<<"name">>, Name} = lists:keyfind(<<"name">>, 1, RR),

--- a/apps/dcos_net/src/dcos_net.app.src
+++ b/apps/dcos_net/src/dcos_net.app.src
@@ -7,7 +7,8 @@
    [kernel,
     stdlib,
     lashup,
-    lager
+    lager,
+    ranch
    ]},
   {env,[]},
   {modules, []},

--- a/apps/dcos_net/src/dcos_net_app.erl
+++ b/apps/dcos_net/src/dcos_net_app.erl
@@ -186,10 +186,10 @@ load_plugin({App, AppPath}) ->
     case code:add_pathz(AppPath) of
         true ->
             load_modules(App, AppPath),
-            case application:start(App) of
+            case application:ensure_all_started(App) of
                 {error, Error} ->
                     lager:error("Plugin ~p: ~p", [App, Error]);
-                ok -> ok
+                {ok, _Apps} -> ok
             end;
         {error, bad_directory} ->
             lager:error("Plugin ~p: bad_directory", [App])

--- a/apps/dcos_rest/src/dcos_rest_dns_handler.erl
+++ b/apps/dcos_rest/src/dcos_rest_dns_handler.erl
@@ -145,6 +145,12 @@ record_to_term(#dns_rr{
       <<"host">> => ntoa(Ip),
       <<"rtype">> => <<"A">>};
 record_to_term(#dns_rr{
+        name = Name, type = ?DNS_TYPE_AAAA,
+        data = #dns_rrdata_aaaa{ip = Ip}}) ->
+    #{<<"name">> => Name,
+      <<"host">> => ntoa(Ip),
+      <<"rtype">> => <<"AAAA">>};
+record_to_term(#dns_rr{
         name = Name, type = ?DNS_TYPE_SRV,
         data = #dns_rrdata_srv{port = Port, target = Target}}) ->
     PortBin = integer_to_binary(Port),

--- a/apps/dcos_rest/src/dcos_rest_dns_handler.erl
+++ b/apps/dcos_rest/src/dcos_rest_dns_handler.erl
@@ -1,4 +1,4 @@
--module(dcos_dns_http_handler).
+-module(dcos_rest_dns_handler).
 
 -export([
     init/3,

--- a/apps/dcos_rest/src/dcos_rest_sup.erl
+++ b/apps/dcos_rest/src/dcos_rest_sup.erl
@@ -17,7 +17,14 @@ setup_cowboy() ->
             {"/lashup/kv/[...]", dcos_rest_lashup_handler, []},
             {"/lashup/key", dcos_rest_key_handler, []},
             {"/v1/vips", dcos_rest_vips_handler, []},
-            {"/status", dcos_rest_status_handler, []}
+            {"/status", dcos_rest_status_handler, []},
+
+            {"/v1/version", dcos_rest_dns_handler, [version]},
+            {"/v1/config", dcos_rest_dns_handler, [config]},
+            {"/v1/hosts/:host", dcos_rest_dns_handler, [hosts]},
+            {"/v1/services/:service", dcos_rest_dns_handler, [services]},
+            {"/v1/enumerate", dcos_rest_dns_handler, [enumerate]},
+            {"/v1/records", dcos_rest_dns_handler, [records]}
         ]}
     ]),
     {ok, Ip} = application:get_env(dcos_rest, ip),

--- a/config/sys.config
+++ b/config/sys.config
@@ -4,7 +4,8 @@
     ]},
 
     {mnesia, [
-        {dir, "/var/lib/dcos/navstar/mnesia"}
+        {dir, "/var/lib/dcos/navstar/mnesia"},
+        {dump_log_write_threshold, 10}
     ]},
 
     {dcos_rest, [

--- a/config/sys.config
+++ b/config/sys.config
@@ -30,38 +30,11 @@
     ]},
 
     {erldns,[
-        {storage, [
-            {type, erldns_storage_json},    %% erldns_storage_json | erldns_storage_mnesia
-            {dir, "db"},
-            {dbname, undefined},  %% name of the db
-            {user, undefined},    %% for future db types
-            {pass, undefined},    %% for future db types
-            {host, undefined},    %% for future db types
-            {port, undefined}     %% for future db types
-        ]},
-        {servers, [[
-            {name, inet_localhost_1},
-            {address, "127.0.0.1"},
-            {port, 62053},
-            {family, inet},
-            {processes, 10}
-        ]]},
+        {servers, []},
         {use_root_hints, false},
         {catch_exceptions, false},
         {zones, "data/zones.json"},
-        {metrics, [
-            {port, 61082}
-        ]},
-        {admin, [
-            {port, 61083},
-            {credentials, {"username", "password"}}
-        ]},
-        {pools, [
-            {tcp_worker_pool, erldns_worker, [
-                {size, 10},
-                {max_overflow, 20}
-            ]}
-        ]}
+        {pools, []}
     ]},
 
     {kernel, [

--- a/config/vm.args
+++ b/config/vm.args
@@ -29,5 +29,7 @@
 ## Scheduler modifications.
 -stbt nnts
 
+## Dirty I/O schedulers
++SDio 0
 
 # This file MUST have extra new lines at the end

--- a/config/vm.args
+++ b/config/vm.args
@@ -4,10 +4,6 @@
 ## Cookie for distributed erlang
 -setcookie minuteman
 
-## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
-## (Disabled by default..use with caution!)
-##-heart
-
 ## Enable kernel poll and a few async threads
 +K true
 +A 100
@@ -20,20 +16,18 @@
 
 +P 256000
 
+## Enable time correction
 +C multi_time_warp
 +c true
 
+## Disable a fully connected network for global module
 -connect_all false
 
 ## Increase atom count 4x
 +t 4194304
 
-# Scheduler modifications.
+## Scheduler modifications.
 -stbt nnts
 
-## Dirty schedulers and CPU
--smp enable
-## Dirty Scheduler count is 100% of CPUs, with only 50% online
-+SDPcpu 100:100
 
 # This file MUST have extra new lines at the end

--- a/config/vm.args
+++ b/config/vm.args
@@ -6,15 +6,16 @@
 
 ## Enable kernel poll and a few async threads
 +K true
-+A 100
++A 10
 
 ## Increase number of concurrent ports/sockets
--env ERL_MAX_PORTS 100000
+-env ERL_MAX_PORTS 16384
 
 ## Tweak GC to run more often
 ##-env ERL_FULLSWEEP_AFTER 10
 
-+P 256000
+## Maximum number of simultaneously existing processes
+##+P 262144
 
 ## Enable time correction
 +C multi_time_warp

--- a/config/vm.args
+++ b/config/vm.args
@@ -23,8 +23,6 @@
 +C multi_time_warp
 +c true
 
--epmd_port 61420
-
 -connect_all false
 
 ## Increase atom count 4x

--- a/docs/dcos_dns.md
+++ b/docs/dcos_dns.md
@@ -34,4 +34,4 @@ dcos-dns implements a simple REST API for service discovery over HTTP:
 * GET /v1/enumerate: lists all DNS information (not implemented)
 * GET /v1/records: lists all DNS records
 
-This HTTP API is reachable at http://<host>:63053/. For more information please see Mesos-DNS [documentation](https://github.com/mesosphere/mesos-dns/blob/master/docs/docs/http.md).
+This HTTP API is reachable at http://127.0.0.1:62080/. For more information please see Mesos-DNS [documentation](https://github.com/mesosphere/mesos-dns/blob/master/docs/docs/http.md).

--- a/rebar.config
+++ b/rebar.config
@@ -65,7 +65,8 @@
     {extended_start_script, true},
     {overlay, [
         {mkdir, "log/sasl"},
-        {mkdir, "data/"}
+        {mkdir, "data/"},
+        {copy, "apps/dcos_dns/data/zones.json", "data/zones.json"}
     ]}
 ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -30,7 +30,7 @@
  {<<"eper">>,{pkg,<<"eper">>,<<"0.94.0">>},0},
  {<<"erldns">>,
   {git,"https://github.com/dcos/erl-dns.git",
-       {ref,"9eabdb574b46a6f8afa0e51e9d984dd4774fd80b"}},
+       {ref,"619036d262f6316e5d3a662a79abbf532b658a2a"}},
   0},
  {<<"erlzk">>,{pkg,<<"erlzk">>,<<"0.6.3">>},0},
  {<<"exometer_core">>,


### PR DESCRIPTION
Due to the `hostname` check validation errors for x509 certificates downgrading OTP version to 20.0.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dcos/dcos-net/29)
<!-- Reviewable:end -->
