### PR TITLE
Mark plugins as permanent applications

### DIFF
--- a/apps/dcos_net/src/dcos_net_app.erl
+++ b/apps/dcos_net/src/dcos_net_app.erl
@@ -186,7 +186,7 @@ load_plugin({App, AppPath}) ->
     case code:add_pathz(AppPath) of
         true ->
             load_modules(App, AppPath),
-            case application:ensure_all_started(App) of
+            case application:ensure_all_started(App, permanent) of
                 {error, Error} ->
                     lager:error("Plugin ~p: ~p", [App, Error]);
                 {ok, _Apps} -> ok


### PR DESCRIPTION
Argument `Type` specifies the type of the application. If omitted, it defaults to `temporary`.

https://jira.mesosphere.com/browse/DCOS-20304
https://mesosphere.slack.com/archives/C04GNUUFZ/p1516055322000173?thread_ts=1516016639.000363&cid=C04GNUUFZ