### PR TITLE
Windows part 2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -151,6 +151,16 @@
         {overrides, [
             {override, inotify, [
                 {provider_hooks, [{pre, []}]}
+            ]},
+            {override, enacl, [
+                {plugins, [pc]},
+                {port_specs, [{"priv/enacl_nif.so", ["c_src/*.c"]}]},
+                {provider_hooks, [
+                    {post, [
+                        {compile, {pc, compile}},
+                        {clean, {pc, clean}}
+                    ]}
+                ]}
             ]}
         ]}
     ]}

--- a/rebar.lock
+++ b/rebar.lock
@@ -94,7 +94,7 @@
  {<<"recon">>,{pkg,<<"recon">>,<<"2.3.2">>},0},
  {<<"riak_dt">>,
   {git,"https://github.com/dcos/riak_dt.git",
-       {ref,"bf7a6ec27f4ec2bc0fbc03cf4a2bb4f4dd79677e"}},
+       {ref,"b5c3fa058f9e56ec14f33b68d5d07ea6fbb97538"}},
   0},
  {<<"setup">>,{pkg,<<"setup">>,<<"1.8.4">>},0},
  {<<"sidejob">>,{pkg,<<"sidejob">>,<<"2.1.0">>},0},

--- a/rebar.lock
+++ b/rebar.lock
@@ -104,7 +104,7 @@
   0},
  {<<"telemetry">>,
   {git,"https://github.com/dcos/telemetry-net.git",
-       {ref,"1a2a14949b484bf13a84c9bf1d705cae8ccd4194"}},
+       {ref,"0cbae9d9d39c6ccecad55e3d580627f4667a39d8"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
Updates required for Windows:
- bump riak_dt version
- bump telementry-net version
- override enacl compilation on Windows