### PR TITLE
disables erldns cache to improve latency in resolving the DNS query

### DIFF
--- a/apps/dcos_dns/include/dcos_dns.hrl
+++ b/apps/dcos_dns/include/dcos_dns.hrl
@@ -13,6 +13,7 @@
 -define(DCOS_DIRECTORY(Prefix), <<Prefix, ".thisdcos.directory">>).
 -define(DCOS_DOMAIN, ?DCOS_DIRECTORY("dcos")).
 -define(MESOS_DOMAIN, ?DCOS_DIRECTORY("mesos")).
+-define(DCOS_DNS_TTL, 5).
 
 %% 30 seconds
 -define(DEFAULT_TIMEOUT, 30000).

--- a/apps/dcos_dns/src/dcos_dns_mesos.erl
+++ b/apps/dcos_dns/src/dcos_dns_mesos.erl
@@ -18,8 +18,6 @@
 -type task() :: dcos_net_mesos_listener:task().
 -type task_id() :: dcos_net_mesos_listener:task_id().
 
--define(DCOS_DNS_TTL, 5).
-
 -record(state, {
     ref :: reference(),
     tasks :: #{ task_id() => [dns:dns_rr()] },

--- a/apps/dcos_dns/src/dcos_dns_mesos_dns.erl
+++ b/apps/dcos_dns/src/dcos_dns_mesos_dns.erl
@@ -9,7 +9,6 @@
 -endif.
 
 -define(MESOS_DNS_URI, "http://127.0.0.1:8123/v1/axfr").
--define(DCOS_DNS_TTL, 5).
 
 %% API
 -export([

--- a/config/ct.sys.config
+++ b/config/ct.sys.config
@@ -32,6 +32,9 @@
         {use_root_hints, false},
         {catch_exceptions, false},
         {zones, "data/zones.json"},
+        {packet_cache, [
+            {enabled, false} 
+        ]},
         {pools, [
             {tcp_worker_pool, erldns_worker, [
                 {size, 10},

--- a/config/sys.config
+++ b/config/sys.config
@@ -35,6 +35,9 @@
         {use_root_hints, false},
         {catch_exceptions, false},
         {zones, "data/zones.json"},
+        {packet_cache, [
+            {enabled, false}
+        ]},
         {pools, []}
     ]},
 


### PR DESCRIPTION
It was observed that when a new task is launched then it would
take close to 5 seconds to resolve the DNS even though erldns
had been updated with the new record. This was happening because
of the erldns cache. This patch fixes the issue by disabling the
erldns cache. This might have an impact on erldns but we believe
it should be minimal as all the queries are local to an agent.