### PR TITLE
 Store tasks as LWW lashup values

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
@@ -17,7 +17,8 @@
     key/0, lkey/0, backend/0]).
 
 -record(state, {
-    timer_ref :: reference()
+    timer_ref :: reference(),
+    prev = #{} :: #{task_id() => task()}
 }).
 
 -type task() :: dcos_net_mesos_listener:task().
@@ -53,10 +54,10 @@ handle_call(_Request, _From, State) ->
 handle_cast(_Request, State) ->
     {noreply, State}.
 
-handle_info({timeout, TRef, poll}, #state{timer_ref=TRef}=State) ->
+handle_info({timeout, TRef, poll}, #state{timer_ref=TRef, prev=Prev}=State) ->
     TRef0 = start_poll_timer(),
-    ok = handle_poll(),
-    {noreply, State#state{timer_ref=TRef0}};
+    Tasks = handle_poll(Prev),
+    {noreply, State#state{timer_ref=TRef0, prev=Tasks}};
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -75,22 +76,29 @@ start_poll_timer() ->
     Timeout = dcos_l4lb_config:agent_poll_interval(),
     erlang:start_timer(Timeout, self(), poll).
 
--spec(handle_poll() -> ok).
-handle_poll() ->
+-spec(handle_poll(Tasks) -> Tasks
+    when Tasks :: #{task_id() => task()}).
+handle_poll(Prev) ->
     IsEnabled = dcos_l4lb_config:agent_polling_enabled(),
-    handle_poll(IsEnabled).
+    handle_poll(Prev, IsEnabled).
 
--spec(handle_poll(boolean()) -> ok).
-handle_poll(false) ->
-    ok;
-handle_poll(true) ->
+-spec(handle_poll(Tasks, boolean()) -> Tasks
+    when Tasks :: #{task_id() => task()}).
+handle_poll(Prev, false) ->
+    Prev;
+handle_poll(Prev, true) ->
     try dcos_net_mesos_listener:poll() of
         {error, Error} ->
-            lager:warning("Unable to poll mesos agent: ~p", [Error]);
+            lager:warning("Unable to poll mesos agent: ~p", [Error]),
+            Prev;
+        {ok, Tasks} when Prev =:= Tasks ->
+            Prev;
         {ok, Tasks} ->
-            handle_poll_state(Tasks)
+            ok = handle_poll_state(Tasks),
+            Tasks
     catch error:bad_agent_id ->
-        lager:warning("Mesos agent is not ready")
+        lager:warning("Mesos agent is not ready"),
+        Prev
     end.
 
 -spec(handle_poll_state(#{task_id() => task()}) -> ok).


### PR DESCRIPTION
At the moment, DNS and VIPs records are stored as OR-Sets. This CRDT
data structure is based on vector clocks. Vector Clocks require lots
of memory and disk resources, the merge operation is very expensive.

Each dcos-net agent manages its own subset of mesos tasks with agent
ip as a key. All conflicts are resolved using last-write-wins (LWW)
strategy. This strategy is simple and doesn't require much cpu,
memory, or disk resources. Store the original data about all tasks
instead of storing processed data such as dns records and vip labels.
In the next releases, all submodules generate all records from this
lashup kv map.