### PR TITLE
Minor logging improvements

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_mgr.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mgr.erl
@@ -339,11 +339,13 @@ diff(ListA, ListB) ->
 
 -spec(diff([{A, B}], [{A, B}], [{A, B}], [{A, B}], [{A, B, B}]) ->
     {[{A, B}], [{A, B}], [{A, B, B}]} when A :: term(), B :: term()).
-diff([A|ListA], [A|ListB], Acc, Bcc, Mcc) ->
-    diff(ListA, ListB, Acc, Bcc, Mcc);
 diff([{Key, Va}|ListA], [{Key, Vb}|ListB], Acc, Bcc, Mcc) ->
-    {Ma, Mb} = dcos_net_utils:complement(Vb, Va),
-    diff(ListA, ListB, Acc, Bcc, [{Key, Ma, Mb}|Mcc]);
+    case dcos_net_utils:complement(Vb, Va) of
+        {[], []} ->
+            diff(ListA, ListB, Acc, Bcc, Mcc);
+        {Ma, Mb} ->
+            diff(ListA, ListB, Acc, Bcc, [{Key, Ma, Mb}|Mcc])
+    end;
 diff([A|_]=ListA, [B|ListB], Acc, Bcc, Mcc) when A > B ->
     diff(ListA, ListB, [B|Acc], Bcc, Mcc);
 diff([A|ListA], [B|_]=ListB, Acc, Bcc, Mcc) when A < B ->
@@ -579,7 +581,10 @@ diff_simple_test() ->
         diff([{a, [1, 2, 3]}], [{a, [1, 2, 3]}])),
     ?assertEqual(
         {[{b, []}], [{c, []}, {a, []}], []},
-        diff([{a, []}, {c, []}], [{b, []}])).
+        diff([{a, []}, {c, []}], [{b, []}])),
+    ?assertEqual(
+        {[], [], []},
+        diff([{key, [x, y]}], [{key, [y, x]}])).
 
 diff_backends_test() ->
     Key = {tcp, {11, 136, 231, 163}, 80},

--- a/apps/dcos_net/src/dcos_net_utils.erl
+++ b/apps/dcos_net/src/dcos_net_utils.erl
@@ -27,6 +27,8 @@ complement([], ListB, Acc, Bcc) ->
     {Acc, ListB ++ Bcc};
 complement(ListA, [], Acc, Bcc) ->
     {ListA ++ Acc, Bcc};
+complement(List, List, Acc, Bcc) ->
+    {Acc, Bcc};
 complement([A|ListA], [A|ListB], Acc, Bcc) ->
     complement(ListA, ListB, Acc, Bcc);
 complement([A|_]=ListA, [B|ListB], Acc, Bcc) when A > B ->


### PR DESCRIPTION
Before:

```
diff([{key, [x, y]}], [{key, [y, x]}]) ->
  {[], [], [{key, [], []}]}.
```

After:
```
diff([{key, [x, y]}], [{key, [y, x]}]) ->
  {[], [], []}.
```