### PR TITLE
Skip gen_netlink compilation on Windows

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -151,6 +151,9 @@
             {override, inotify, [
                 {provider_hooks, [{pre, []}]}
             ]},
+            {override, gen_netlink, [
+                {provider_hooks, [{pre, []}]}
+            ]},
             {override, enacl, [
                 {plugins, [{pc, "1.10.0"}]},
                 {port_specs, [{"priv/enacl_nif.so", ["c_src/*.c"]}]},


### PR DESCRIPTION
Netlink sockets do not exist on Windows.

While running dcos-net on Windows they are not used, so skip the compilation of
gen_netlink.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>
CC: @urbanserj 
CC: @GoelDeepak 