### PR TITLE
Fix get_zookeepers/0 for 3-master-node cluster

### DIFF
--- a/apps/dcos_dns/src/dcos_dns.erl
+++ b/apps/dcos_dns/src/dcos_dns.erl
@@ -54,7 +54,7 @@ resolve(DNSName, Family, Timeout) ->
     end.
 
 -spec(imp_resolve(binary(), inet | inet6, timeout()) ->
-    {ok, inet:ip_address()} | {error, term()}).
+    {ok, [inet:ip_address()]} | {error, term()}).
 imp_resolve(<<"localhost">>, inet, _Timeout) ->
     {ok, [{127, 0, 0, 1}]};
 imp_resolve(DNSName, Family, Timeout) ->

--- a/apps/dcos_dns/src/dcos_dns_key_mgr.erl
+++ b/apps/dcos_dns/src/dcos_dns_key_mgr.erl
@@ -202,6 +202,8 @@ get_zookeepers() ->
     lists:map(fun ({Host, Port}) ->
         HostBin = list_to_binary(Host),
         case dcos_dns:resolve(HostBin) of
+            {ok, []} ->
+                {Host, Port};
             {ok, [IPAddr|_IPAddrs]} ->
                 {inet:ntoa(IPAddr), Port};
             {error, _} ->


### PR DESCRIPTION
This bug was introduced in PR #85.

```
1> dcos_dns:resolve(<<"master3.mesos">>).
{ok, []}
```