### PR TITLE
Changes the backend for a VIP in case of docker containerizer

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
@@ -124,10 +124,12 @@ is_healthy(_Task) ->
          Container :: {inet:ip_address(), inet:port_number()}).
 collect_port_mappings(Tasks) ->
     maps:fold(fun (_TaskId, Task, Acc) ->
+        Runtime = maps:get(runtime, Task),
         [TaskIP | _TaskIPs] = maps:get(task_ip, Task),
         PMs = [{{Protocol, Host}, {TaskIP, Port}}
               || #{host_port := Host, protocol := Protocol,
-                   port := Port} <- maps:get(ports, Task, [])],
+                   port := Port} <- maps:get(ports, Task, []),
+                 Runtime =/= docker],
         PMs ++ Acc
     end, [], Tasks).
 

--- a/apps/dcos_l4lb/test/dcos_l4lb_mesos_poller_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_mesos_poller_SUITE.erl
@@ -1,19 +1,26 @@
 -module(dcos_l4lb_mesos_poller_SUITE).
 
+-include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include("dcos_l4lb.hrl").
 
 -export([
     all/0,
     init_per_suite/1, end_per_suite/1,
-    init_per_testcase/2, end_per_testcase/2,
-    test_lashup/1
+    init_per_testcase/2, end_per_testcase/2
+]).
+
+-export([
+    test_lashup/1,
+    test_mesos_portmapping/1
 ]).
 
 
 %% root tests
-all() ->
-    [test_lashup].
+all() -> [
+    test_lashup,
+    test_mesos_portmapping
+].
 
 init_per_suite(Config) ->
     Config.
@@ -23,23 +30,14 @@ end_per_suite(Config) ->
 
 init_per_testcase(_, Config) ->
     meck:new(dcos_net_mesos_listener, [no_link]),
-    meck:expect(dcos_net_mesos_listener, poll, fun () ->
-        {ok, #{
-            <<"app.6e53a5c1-1f27-11e6-bc04-4e40412869d8">> => #{
-                name => <<"app">>,
-                framework => <<"marathon">>,
-                agent_ip => {10, 0, 0, 243},
-                task_ip => [{10, 0, 0, 243}],
-                ports => [
-                    #{name => <<"http">>, protocol => tcp,
-                      port => 12049, vip => [<<"merp:5000">>]}
-                ],
-                state => running
-            }
-        }}
-    end),
+    meck:expect(dcos_net_mesos_listener, poll, fun meck_mesos_poll/0),
+
+    meck:new(dcos_l4lb_mgr, [no_link]),
+    meck:expect(dcos_l4lb_mgr, local_port_mappings, fun (_) -> ok end),
+
     {ok, _} = application:ensure_all_started(dcos_l4lb),
     meck:wait(dcos_net_mesos_listener, poll, '_', 5000),
+    meck:wait(dcos_l4lb_mgr, local_port_mappings, '_', 100),
     timer:sleep(100),
     Config.
 
@@ -51,8 +49,30 @@ end_per_testcase(_, _Config) ->
     not lists:member(App, [stdlib, kernel]) ],
     os:cmd("rm -rf Mnesia.*"),
     meck:unload(dcos_net_mesos_listener),
+    meck:unload(dcos_l4lb_mgr),
     ok.
+
+meck_mesos_poll() ->
+    {ok, #{
+        <<"app.6e53a5c1-1f27-11e6-bc04-4e40412869d8">> => #{
+            name => <<"app">>,
+            runtime => mesos,
+            framework => <<"marathon">>,
+            agent_ip => {10, 0, 0, 243},
+            task_ip => [{9, 0, 1, 29}],
+            ports => [
+                #{name => <<"http">>, protocol => tcp, host_port => 12049,
+                  port => 80, vip => [<<"merp:5000">>]}
+            ],
+            state => running
+        }
+    }}.
 
 test_lashup(_Config) ->
     Value = lashup_kv:value(?VIPS_KEY2),
     [{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12049}}]}] = Value.
+
+test_mesos_portmapping(_Config) ->
+    Expected = [{{tcp, 12049}, {{9, 0, 1, 29}, 80}}],
+    Actual = meck:capture(first, dcos_l4lb_mgr, local_port_mappings, '_', 1),
+    ?assertMatch(Expected, Actual).

--- a/apps/dcos_net/test/dcos_net_mesos_listener_tests.erl
+++ b/apps/dcos_net/test/dcos_net_mesos_listener_tests.erl
@@ -57,6 +57,7 @@ vip_labels_test() ->
     ?assertEqual(#{
         {FrameworkId, TaskId} => #{
             name => <<"app">>,
+            runtime => mesos,
             framework => <<"marathon">>,
             agent_ip => {172, 17, 0, 3},
             task_ip => [{172, 17, 0, 3}],
@@ -84,6 +85,7 @@ dns_hostname_test() ->
     ?assertEqual(#{
         {FrameworkId, TaskId} => #{
             name => <<"test">>,
+            runtime => docker,
             framework => <<"marathon">>,
             agent_ip => {127, 0, 0, 1},
             task_ip => [{127, 0, 0, 1}],
@@ -99,6 +101,7 @@ tcp_udp_test() ->
     ?assertEqual(#{
         {FrameworkId, TaskId} => #{
             name => <<"app">>,
+            runtime => docker,
             framework => <<"marathon">>,
             agent_ip => {172, 17, 0, 3},
             task_ip => [{172, 17, 0, 3}],
@@ -125,6 +128,7 @@ unhealthy_test() ->
     ?assertEqual(#{
         {FrameworkId, TaskId} => #{
             name => <<"app">>,
+            runtime => mesos,
             framework => <<"marathon">>,
             agent_ip => {172, 17, 0, 4},
             task_ip => [{9, 0, 1, 6}],
@@ -153,6 +157,7 @@ none_on_host(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"none-on-host">>,
+        runtime => mesos,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 4},
         task_ip => [{172, 17, 0, 4}],
@@ -168,6 +173,7 @@ none_on_dcos(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"none-on-dcos">>,
+        runtime => mesos,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 4},
         task_ip => [{9, 0, 2, 5}],
@@ -179,6 +185,7 @@ ucr_on_host(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"ucr-on-host">>,
+        runtime => mesos,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 3},
         task_ip => [{172, 17, 0, 3}],
@@ -194,6 +201,7 @@ ucr_on_bridge(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"ucr-on-bridge">>,
+        runtime => mesos,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 3},
         task_ip => [{172, 31, 254, 3}],
@@ -209,6 +217,7 @@ ucr_on_dcos(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"ucr-on-dcos">>,
+        runtime => mesos,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 3},
         task_ip => [{9, 0, 1, 6}],
@@ -220,6 +229,7 @@ docker_on_host(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"docker-on-host">>,
+        runtime => docker,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 4},
         task_ip => [{172, 17, 0, 4}],
@@ -235,6 +245,7 @@ docker_on_bridge(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"docker-on-bridge">>,
+        runtime => docker,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 4},
         task_ip => [{172, 18, 0, 2}],
@@ -250,6 +261,7 @@ docker_on_dcos(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"docker-on-dcos">>,
+        runtime => docker,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 4},
         task_ip => [{9, 0, 2, 130}],
@@ -266,6 +278,7 @@ docker_on_ipv6(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"docker-on-ipv6">>,
+        runtime => docker,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 4},
         task_ip => [{172, 19, 0, 2}, IPv6],
@@ -281,6 +294,7 @@ pod_on_host(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"pod-on-host">>,
+        runtime => mesos,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 4},
         task_ip => [{172, 17, 0, 4}],
@@ -296,6 +310,7 @@ pod_on_bridge(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"pod-on-bridge">>,
+        runtime => mesos,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 3},
         task_ip => [{172, 31, 254, 4}],
@@ -311,6 +326,7 @@ pod_on_dcos(Tasks) ->
     FrameworkId = <<"30257977-0153-499d-a5b0-35afd842ef4d-0001">>,
     ?assertEqual(#{
         name => <<"pod-on-dcos">>,
+        runtime => mesos,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 3},
         task_ip => [{9, 0, 1, 3}],
@@ -330,6 +346,7 @@ hello_overlay_world(Tasks) ->
     FrameworkId = <<"c620b0f5-ce56-472b-814a-aa36b40206af-0001">>,
     ?assertEqual(#{
         name => <<"hello-world">>,
+        runtime => unknown,
         framework => <<"marathon">>,
         agent_ip => {10, 0, 0, 49},
         task_ip => [{10, 0, 0, 49}],
@@ -345,6 +362,7 @@ hello_overlay_server(Tasks) ->
     FrameworkId = <<"c620b0f5-ce56-472b-814a-aa36b40206af-0002">>,
     ?assertEqual(#{
         name => <<"hello-overlay-0-server">>,
+        runtime => mesos,
         framework => <<"hello-world">>,
         agent_ip => {10, 0, 0, 49},
         task_ip => [{9, 0, 2, 2}],
@@ -362,6 +380,7 @@ hello_overlay_vip(Tasks) ->
     FrameworkId = <<"c620b0f5-ce56-472b-814a-aa36b40206af-0002">>,
     ?assertEqual(#{
         name => <<"hello-overlay-vip-0-server">>,
+        runtime => mesos,
         framework => <<"hello-world">>,
         agent_ip => {10, 0, 0, 49},
         task_ip => [{9, 0, 2, 3}],
@@ -377,6 +396,7 @@ hello_overlay_host_vip(Tasks) ->
     FrameworkId = <<"c620b0f5-ce56-472b-814a-aa36b40206af-0002">>,
     ?assertEqual(#{
         name => <<"hello-host-vip-0-server">>,
+        runtime => mesos,
         framework => <<"hello-world">>,
         agent_ip => {10, 0, 0, 49},
         task_ip => [{10, 0, 0, 49}],
@@ -396,6 +416,7 @@ pod_tasks(Tasks) ->
     Framework = <<"8ae294b7-a766-42d6-960c-ad8acf0f0db6-0000">>,
     Task = #{
         name => <<"app">>,
+        runtime => mesos,
         framework => <<"marathon">>,
         agent_ip => {172, 17, 0, 3},
         task_ip => [{9, 0, 0, 2}],


### PR DESCRIPTION
In case of docker containerizer if the backend to a VIP is the
actual container ip then the application running in the container
cannot access its own VIP. The only way to make it work is to go
through port mapping. This patch fixes the port mapping such that
the backend is the host IP:port intead of container ip:port

jira: DCOS-45115