### PR TITLE
Makes erlang cookie configurable

### DIFF
--- a/config/vm.args
+++ b/config/vm.args
@@ -2,7 +2,7 @@
 -name ${NAME}
 
 ## Cookie for distributed erlang
--setcookie minuteman
+-setcookie ${COOKIE}
 
 ## Increase number of concurrent ports/sockets
 -env ERL_MAX_PORTS 16384


### PR DESCRIPTION
Erlang cookie serves as membership token in a distributed system.
Having it configurable would allow different DC/OS clusters to
co-exist without interfering each other.

jira: DCOS_OSS-4620