### PR TITLE
Update Makefile to supporte latest dcos-e2e/minidcos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,9 +162,9 @@ dcos-docker-destroy:
 	@ minidcos docker destroy --cluster-id $(DCOS_DOCKER_CLUSTER_ID)
 
 dcos-docker-web: dcos-docker-create
-	@ docker ps \
-	    --filter label=dcos-e2e-web-id=$(DCOS_DOCKER_CLUSTER_ID) \
-	    --filter label=dcos-e2e-web-port=$(DCOS_DOCKER_WEB_PORT) \
+	-@ docker ps \
+	    --filter label=minidcos-web-id=$(DCOS_DOCKER_CLUSTER_ID) \
+	    --filter label=minidcos-web-port=$(DCOS_DOCKER_WEB_PORT) \
 	    --format '{{.ID}}' \
 	| xargs docker kill > /dev/null
 	@ docker run \
@@ -173,8 +173,8 @@ dcos-docker-web: dcos-docker-create
 	    --name $(shell minidcos docker inspect --cluster-id $(DCOS_DOCKER_CLUSTER_ID) | \
 	                   jq -r .Nodes.masters[0].docker_container_name | \
 	                   sed -re 's/-master-0/-web-$(DCOS_DOCKER_WEB_PORT)/') \
-	    --label dcos-e2e-web-id=$(DCOS_DOCKER_CLUSTER_ID) \
-	    --label dcos-e2e-web-port=$(DCOS_DOCKER_WEB_PORT) \
+	    --label minidcos-web-id=$(DCOS_DOCKER_CLUSTER_ID) \
+	    --label minidcos-web-port=$(DCOS_DOCKER_WEB_PORT) \
 	    alpine/socat TCP4-LISTEN:$(DCOS_DOCKER_WEB_PORT),bind=0.0.0.0,reuseaddr,fork,su=nobody \
 	                 TCP4:$(shell minidcos docker inspect --cluster-id $(DCOS_DOCKER_CLUSTER_ID) | \
 	                              jq '.Nodes | .[] | .[]' | \

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ minidcos-destroy:
 	@ docker ps \
 	    --filter label=dcos-e2e-web-id=$(MINIDCOS_CLUSTER_ID) \
 	    --format '{{.ID}}' \
-	| xargs docker kill > /dev/null
+	| xargs --no-run-if-empty docker kill > /dev/null
 	@ minidcos docker destroy --cluster-id $(MINIDCOS_CLUSTER_ID)
 
 minidcos-web: minidcos-create
@@ -166,7 +166,7 @@ minidcos-web: minidcos-create
 	    --filter label=minidcos-web-id=$(MINIDCOS_CLUSTER_ID) \
 	    --filter label=minidcos-web-port=$(MINIDCOS_WEB_PORT) \
 	    --format '{{.ID}}' \
-	| xargs docker kill > /dev/null
+	| xargs --no-run-if-empty docker kill > /dev/null
 	@ docker run \
 	    --rm --detach \
 	    --publish $(MINIDCOS_WEB_PORT):$(MINIDCOS_WEB_PORT) \

--- a/Makefile
+++ b/Makefile
@@ -156,15 +156,16 @@ minidcos-create:
 
 minidcos-destroy:
 	@ docker ps \
-	    --filter label=minidcos-web-id=$(MINIDCOS_CLUSTER_ID) \
+      --filter label=dcos_e2e.cluster_id=$(MINIDCOS_CLUSTER_ID) \
+      --filter label=dcos_e2e.web_port \
 	    --format '{{.ID}}' \
 	| xargs --no-run-if-empty docker kill > /dev/null
 	@ minidcos docker destroy --cluster-id $(MINIDCOS_CLUSTER_ID)
 
 minidcos-web: minidcos-create
 	-@ docker ps \
-	    --filter label=minidcos-web-id=$(MINIDCOS_CLUSTER_ID) \
-	    --filter label=minidcos-web-port=$(MINIDCOS_WEB_PORT) \
+	    --filter label=dcos_e2e.cluster_id=$(MINIDCOS_CLUSTER_ID) \
+	    --filter label=dcos_e2e.web_port=$(MINIDCOS_WEB_PORT) \
 	    --format '{{.ID}}' \
 	| xargs --no-run-if-empty docker kill > /dev/null
 	@ docker run \
@@ -173,8 +174,8 @@ minidcos-web: minidcos-create
 	    --name $(shell minidcos docker inspect --cluster-id $(MINIDCOS_CLUSTER_ID) | \
 	                   jq -r .Nodes.masters[0].docker_container_name | \
 	                   sed -re 's/-master-0/-web-$(MINIDCOS_WEB_PORT)/') \
-	    --label minidcos-web-id=$(MINIDCOS_CLUSTER_ID) \
-	    --label minidcos-web-port=$(MINIDCOS_WEB_PORT) \
+	    --label dcos_e2e.cluster_id=$(MINIDCOS_CLUSTER_ID) \
+	    --label dcos_e2e.web_port=$(MINIDCOS_WEB_PORT) \
 	    alpine/socat TCP4-LISTEN:$(MINIDCOS_WEB_PORT),bind=0.0.0.0,reuseaddr,fork,su=nobody \
 	                 TCP4:$(shell minidcos docker inspect --cluster-id $(MINIDCOS_CLUSTER_ID) | \
 	                              jq '.Nodes | .[] | .[]' | \

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ dev: dev-install dev-stop
 	  /opt/mesosphere/bin/dcos-net-env console
 
 ##
-## MINI DC/OS
+## miniDC/OS
 ##
 
 MINIDCOS_TRANSPORT ?= docker-exec
@@ -156,18 +156,18 @@ minidcos-create:
 
 minidcos-destroy:
 	@ docker ps \
-      --filter label=dcos_e2e.cluster_id=$(MINIDCOS_CLUSTER_ID) \
-      --filter label=dcos_e2e.web_port \
+	    --filter label=dcos_e2e.cluster_id=$(MINIDCOS_CLUSTER_ID) \
+	    --filter label=dcos_e2e.web_port \
 	    --format '{{.ID}}' \
-	| xargs --no-run-if-empty docker kill > /dev/null
+	    | while read id; do [ -z "$id" ] || docker kill $id; done > /dev/null
 	@ minidcos docker destroy --cluster-id $(MINIDCOS_CLUSTER_ID)
 
 minidcos-web: minidcos-create
-	-@ docker ps \
+	@ docker ps \
 	    --filter label=dcos_e2e.cluster_id=$(MINIDCOS_CLUSTER_ID) \
 	    --filter label=dcos_e2e.web_port=$(MINIDCOS_WEB_PORT) \
 	    --format '{{.ID}}' \
-	| xargs --no-run-if-empty docker kill > /dev/null
+	    | while read id; do [ -z "$id" ] || docker kill $id; done > /dev/null
 	@ docker run \
 	    --rm --detach \
 	    --publish $(MINIDCOS_WEB_PORT):$(MINIDCOS_WEB_PORT) \

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ minidcos-destroy:
 	    --filter label=dcos_e2e.cluster_id=$(MINIDCOS_CLUSTER_ID) \
 	    --filter label=dcos_e2e.web_port \
 	    --format '{{.ID}}' \
-	    | while read id; do [ -z "$id" ] || docker kill $id; done > /dev/null
+	| while read id; do [ -z "$$id" ] || docker kill $$id; done > /dev/null
 	@ minidcos docker destroy --cluster-id $(MINIDCOS_CLUSTER_ID)
 
 minidcos-web: minidcos-create
@@ -167,7 +167,7 @@ minidcos-web: minidcos-create
 	    --filter label=dcos_e2e.cluster_id=$(MINIDCOS_CLUSTER_ID) \
 	    --filter label=dcos_e2e.web_port=$(MINIDCOS_WEB_PORT) \
 	    --format '{{.ID}}' \
-	    | while read id; do [ -z "$id" ] || docker kill $id; done > /dev/null
+	| while read id; do [ -z "$$id" ] || docker kill $$id; done > /dev/null
 	@ docker run \
 	    --rm --detach \
 	    --publish $(MINIDCOS_WEB_PORT):$(MINIDCOS_WEB_PORT) \

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ minidcos-create:
 
 minidcos-destroy:
 	@ docker ps \
-	    --filter label=dcos-e2e-web-id=$(MINIDCOS_CLUSTER_ID) \
+	    --filter label=minidcos-web-id=$(MINIDCOS_CLUSTER_ID) \
 	    --format '{{.ID}}' \
 	| xargs --no-run-if-empty docker kill > /dev/null
 	@ minidcos docker destroy --cluster-id $(MINIDCOS_CLUSTER_ID)

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ dev-stop:
 	    echo "options attempts:3" && \
 	    echo $(shell source /opt/mesosphere/etc/dns_config && \
 	                 echo $${RESOLVERS} | \
-	                 sed -re 's/(^|[,])/\nnameserver /g') \
+	                 sed -e 's/(^|[,])/\nnameserver /g') \
 	  ) > /etc/resolv.conf
 
 dev-start:
@@ -118,7 +118,7 @@ console: dev-shell
 
 dev: dev-install dev-stop
 	@ export ENABLE_CHECK_TIME=false && \
-	  systemctl cat dcos-net | sed -nre 's/ExecStartPre=//p' | tr '\n' '\0' | \
+	  systemctl cat dcos-net | sed -ne 's/ExecStartPre=//p' | tr '\n' '\0' | \
 	    xargs -0 -n 1 /opt/mesosphere/bin/dcos-shell bash -c
 	@ DCOS_NET_ENV_CMD="make" \
 	  DCOS_NET_EBIN="$(BUILD_DIR)/default/lib/dcos_net/ebin" \
@@ -173,7 +173,7 @@ minidcos-web: minidcos-create
 	    --publish $(MINIDCOS_WEB_PORT):$(MINIDCOS_WEB_PORT) \
 	    --name $(shell minidcos docker inspect --cluster-id $(MINIDCOS_CLUSTER_ID) | \
 	                   jq -r .Nodes.masters[0].docker_container_name | \
-	                   sed -re 's/-master-0/-web-$(MINIDCOS_WEB_PORT)/') \
+	                   sed -e 's/-master-0/-web-$(MINIDCOS_WEB_PORT)/') \
 	    --label dcos_e2e.cluster_id=$(MINIDCOS_CLUSTER_ID) \
 	    --label dcos_e2e.web_port=$(MINIDCOS_WEB_PORT) \
 	    alpine/socat TCP4-LISTEN:$(MINIDCOS_WEB_PORT),bind=0.0.0.0,reuseaddr,fork,su=nobody \

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ You can build, check, and test dcos-net in a development image using
 All makefile targets with `docker-` prefix build development image with all
 dependencies and run `rebar3` in that image on the host directory.
 
-To check your dcos-net build on DC/OS you can use DC/OS E2E a.k.a.
-[dcos-docker CLI](http://dcos-e2e.readthedocs.io/en/latest/cli.html). In order to do so please repeat the following steps:
+To check your dcos-net build on DC/OS you can use [minidcos](https://dcos-e2e-cli.readthedocs.io/en/latest/). In order to do so please repeat the following steps:
 
 1. Download a DC/OS build:
 

--- a/README.md
+++ b/README.md
@@ -64,26 +64,26 @@ To check your dcos-net build on DC/OS you can use [minidcos](https://dcos-e2e-cl
    be 1 node):
 
    ```sh
-   make dcos-docker-create DCOS_DOCKER_AGENTS=3
+   make minidcos-create MINIDCOS_AGENTS=3
    ```
 
 1. Build and run `dcos-net` off you local repository on a particular node, in
    this case it is `master_0`:
 
    ```sh
-   make dcos-docker-dev DCOS_DOCKER_NODE=master_0
+   make minidcos-dev MINIDCOS_NODE=master_0
    ```
 
 1. Open `dcos-shell` on a node (`agent_0`, `agent_1`, `...` `agent_n`):
 
    ```sh
-   make dcos-docker-shell DCOS_DOCKER_NODE=agent_1
+   make minidcos-shell MINIDCOS_NODE=agent_1
    ```
 
 1. Destroy the cluster:
 
    ```sh
-   make dcos-docker-destroy
+   make minidcos-destroy
    ```
 
 Alternatively, you may build and run all the components yourself. Please refer

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can build, check, and test dcos-net in a development image using
 All makefile targets with `docker-` prefix build development image with all
 dependencies and run `rebar3` in that image on the host directory.
 
-To check your dcos-net build on DC/OS you can use [minidcos](https://dcos-e2e-cli.readthedocs.io/en/latest/). In order to do so please repeat the following steps:
+To check your dcos-net build on DC/OS you can use [miniDC/OS](https://dcos-e2e-cli.readthedocs.io/en/latest/). In order to do so please repeat the following steps:
 
 1. Download a DC/OS build:
 


### PR DESCRIPTION
Worth of notice:
- Renamed `dcos-e2e` command to `minidcos` to work with the newest version of `minidcos`.
- Made a change on `dcos-docker-web` target runs even if there is no `socat` container.
- Renamed some filters to get rid of the `dcos-e2e` string.