### PR TITLE
Allow any content type params in metrics handler

### DIFF
--- a/apps/dcos_rest/src/dcos_rest_metrics_handler.erl
+++ b/apps/dcos_rest/src/dcos_rest_metrics_handler.erl
@@ -19,7 +19,7 @@ allowed_methods(Req, State) ->
 
 content_types_provided(Req, State) ->
     {[
-        {{<<"text">>, <<"plain">>, []}, metrics}
+        {{<<"text">>, <<"plain">>, '*'}, metrics}
     ], Req, State}.
 
 metrics(Req, State) ->


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS_OSS-4738

Telegraf polls metrics from dcos-net with the following `Accept` header: application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3`.

`[]` content type params mean that we don't expect any params.
`'*'` means that all content type params will be ignored.