### PR TITLE
Add metrics for dns forwarders

### DIFF
--- a/apps/dcos_dns/src/dcos_dns.app.src
+++ b/apps/dcos_dns/src/dcos_dns.app.src
@@ -22,7 +22,8 @@
         ranch,
         sidejob,
         cowboy,
-        dcos_net
+        dcos_net,
+        prometheus
     ]},
     {env,[]},
     {modules, []},

--- a/apps/dcos_dns/src/dcos_dns_mesos.erl
+++ b/apps/dcos_dns/src/dcos_dns_mesos.erl
@@ -274,15 +274,8 @@ push_tasks(Tasks) ->
 format_name(ListOfNames, Postfix) ->
     ListOfNames1 = lists:map(fun mesos_state:label/1, ListOfNames),
     ListOfNames2 = lists:map(fun list_to_binary/1, ListOfNames1),
-    Prefix = join(ListOfNames2, <<".">>),
+    Prefix = dcos_net_utils:join(ListOfNames2, <<".">>),
     <<Prefix/binary, ".", Postfix/binary>>.
-
--spec(join([binary()], binary()) -> binary()).
-join(List, Sep) ->
-    SepSize = size(Sep),
-    <<Sep:SepSize/binary, Result/binary>> =
-        << <<Sep/binary, X/binary>> || X <- List >>,
-    Result.
 
 %%%===================================================================
 %%% Lashup functions

--- a/apps/dcos_dns/src/dcos_dns_sup.erl
+++ b/apps/dcos_dns/src/dcos_dns_sup.erl
@@ -13,6 +13,7 @@ init([false]) ->
 init([true]) ->
     %% Configure metrics.
     dcos_dns_metrics:setup(),
+    dcos_dns_handler:init_metrics(),
 
     %% Setup ready.spartan zone / record
     ok = dcos_dns_zone_setup(),

--- a/apps/dcos_net/src/dcos_net_utils.erl
+++ b/apps/dcos_net/src/dcos_net_utils.erl
@@ -103,5 +103,16 @@ system_timeout_test() ->
         {error, enoent} -> ok;
         {error, timeout} -> ok
     end.
+%%%===================================================================
+%%% Binary functions
+%%%===================================================================
 
 -endif.
+-spec(join([binary()], binary()) -> binary()).
+join([], _Sep) ->
+    <<>>;
+join(List, Sep) ->
+    SepSize = size(Sep),
+    <<Sep:SepSize/binary, Result/binary>> =
+        << <<Sep/binary, X/binary>> || X <- List >>,
+    Result.

--- a/apps/dcos_net/src/dcos_net_utils.erl
+++ b/apps/dcos_net/src/dcos_net_utils.erl
@@ -1,13 +1,10 @@
 -module(dcos_net_utils).
 
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--endif.
-
 -export([
     complement/2,
     system/1,
-    system/2
+    system/2,
+    join/2
 ]).
 
 %%%===================================================================
@@ -37,19 +34,6 @@ complement([A|_]=ListA, [B|ListB], Acc, Bcc) when A > B ->
     complement(ListA, ListB, Acc, [B|Bcc]);
 complement([A|ListA], [B|_]=ListB, Acc, Bcc) when A < B ->
     complement(ListA, ListB, [A|Acc], Bcc).
-
--ifdef(TEST).
-
-complement_test() ->
-    {A, B} =
-        complement(
-            [a, 0, b, 1, c, 2],
-            [e, 0, d, 1, f, 2]),
-    ?assertEqual(
-        {[a, b, c], [d, e, f]},
-        {lists:sort(A), lists:sort(B)}).
-
--endif.
 
 %%%===================================================================
 %%% System functions
@@ -88,26 +72,10 @@ system_loop(Port, EndTime, Acc) ->
         {error, timeout}
     end.
 
--ifdef(TEST).
-
-system_test() ->
-    case system([<<"/bin/pwd">>]) of
-        {error, enoent} -> ok;
-        {ok, Pwd} ->
-            {ok, Cwd} = file:get_cwd(),
-            ?assertEqual(iolist_to_binary([Cwd, "\n"]), Pwd)
-    end.
-
-system_timeout_test() ->
-    case system([<<"/bin/dd">>], 100) of
-        {error, enoent} -> ok;
-        {error, timeout} -> ok
-    end.
 %%%===================================================================
 %%% Binary functions
 %%%===================================================================
 
--endif.
 -spec(join([binary()], binary()) -> binary()).
 join([], _Sep) ->
     <<>>;

--- a/apps/dcos_net/test/dcos_net_utils_tests.erl
+++ b/apps/dcos_net/test/dcos_net_utils_tests.erl
@@ -1,0 +1,41 @@
+-module(dcos_net_utils_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+join_empty_bin_test_() -> [
+    ?_assertEqual(
+       <<>>,
+       dcos_net_utils:join([], <<"no">>)),
+    ?_assertEqual(
+       <<>>,
+       dcos_net_utils:join([], <<>>)),
+    ?_assertEqual(
+       <<>>,
+       dcos_net_utils:join([<<>>], <<>>)),
+    ?_assertEqual(
+       <<"a">>,
+       dcos_net_utils:join([<<"a">>], <<>>)),
+    ?_assertEqual(
+       <<"ab">>,
+       dcos_net_utils:join([<<"a">>, <<"b">>], <<>>)),
+    ?_assertEqual(
+       <<"yes">>,
+       dcos_net_utils:join([<<>>, <<>>], <<"yes">>))
+].
+
+join_basic_test_() -> [
+    ?_assertEqual(
+       <<"foo">>,
+       dcos_net_utils:join([<<"foo">>], <<".">>)),
+    ?_assertEqual(
+       <<"foo.bar">>,
+       dcos_net_utils:join([<<"foo">>, <<"bar">>], <<".">>)),
+    ?_assertEqual(
+       <<"foo...bar">>,
+       dcos_net_utils:join([<<"foo">>, <<"bar">>], <<"...">>)),
+    ?_assertEqual(
+       <<"foo。bar">>,
+       dcos_net_utils:join([<<"foo">>, <<"bar">>], <<"。">>)),
+    ?_assertEqual(
+       <<"foo.bar.">>,
+       dcos_net_utils:join([<<"foo">>, <<"bar">>, <<>>], <<".">>))
+].

--- a/apps/dcos_net/test/dcos_net_utils_tests.erl
+++ b/apps/dcos_net/test/dcos_net_utils_tests.erl
@@ -1,6 +1,29 @@
 -module(dcos_net_utils_tests).
 -include_lib("eunit/include/eunit.hrl").
 
+complement_test() ->
+    {A, B} =
+        dcos_net_utils:complement(
+          [a, 0, b, 1, c, 2],
+          [e, 0, d, 1, f, 2]),
+    ?assertEqual(
+       {[a, b, c], [d, e, f]},
+       {lists:sort(A), lists:sort(B)}).
+
+system_test() ->
+    case dcos_net_utils:system([<<"/bin/pwd">>]) of
+        {error, enoent} -> ok;
+        {ok, Pwd} ->
+            {ok, Cwd} = file:get_cwd(),
+            ?assertEqual(iolist_to_binary([Cwd, "\n"]), Pwd)
+    end.
+
+system_timeout_test() ->
+    case dcos_net_utils:system([<<"/bin/dd">>], 100) of
+        {error, enoent} -> ok;
+        {error, timeout} -> ok
+    end.
+
 join_empty_bin_test_() -> [
     ?_assertEqual(
        <<>>,


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-48336

Related PR on dcos: https://github.com/dcos/dcos/pull/4672

Adds two metrics for dcos-dns according to the [Metrics design spreadsheet](https://docs.google.com/spreadsheets/d/1bXL2wtTYd-aHJ6r1RbXEJGOQQBcL8REzuC8ZfsHFA7k/edit#gid=1194055742).

You can test it using this [super hacky/beta dashboard](https://gist.github.com/Fabs/0c6a216fdaed07922ee1dddd431f6f8b#file-dns-dashboard-debug-json) I put together, using the steps below (the dashboard is not really good, it just shows some metrics):

# Testing this PR
### create a cluster
make minidcos-create

### setup cli for the created cluster
```
dcos marathon pod add https://raw.githubusercontent.com/dcos/dcos-metrics/master/docs/resources/metrics.json
dcos marathon app add https://raw.githubusercontent.com/dcos/dcos-metrics/master/docs/resources/prometheus.json
dcos marathon app add https://raw.githubusercontent.com/dcos/dcos-metrics/master/docs/resources/grafana.json
```

### edit telegraf.conf
- make minidcos-shell
- go to this file `/opt/mesosphere/etc/telegraf/telegraf.conf`
```
[[inputs.prometheus]]
  ## An array of urls to scrape metrics from.
  urls = [
      "http://127.0.0.1:62080/v1/metrics/default",
      "http://127.0.0.1:62080/v1/metrics/dns"
  ]
```
- systemctl restart dcos-telegraf

### compile this branch to the master_0 node
make minidcos-dev

### Open grafana (on make you might need `make minidcos-web`
http://$master-ip/services/grafana

### Add a data source
- Click add data source
- Set the url http://localhost:9090 (it needs to be white not gray)

### Add a Dashboard
- Click `+` on the left main menu and import this dashboard:
https://gist.github.com/Fabs/0c6a216fdaed07922ee1dddd431f6f8b#file-dns-dashboard-debug-json

![dns-alpha-dashboard](https://user-images.githubusercontent.com/10524/53534933-a8620b00-3ab5-11e9-91b2-88d57e659dff.png)