### PR TITLE
Update Makefile to supporte latest dcos-e2e/minidcos [2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,12 +136,13 @@ MINIDCOS_AGENTS ?= 1
 MINIDCOS_PUBLIC_AGENTS ?= 0
 MINIDCOS_NODE ?= master_0
 MINIDCOS_WEB_PORT ?= 443
+MINIDCOS_INTALLER ?= dcos_generate_config.sh
 
 minidcos-create:
 	@ minidcos docker inspect \
 	      --cluster-id $(MINIDCOS_CLUSTER_ID) \
 	      > /dev/null 2> /dev/null || \
-	( minidcos docker create dcos_generate_config.sh \
+	( minidcos docker create $(MINIDCOS_INTALLER) \
 	      --transport $(MINIDCOS_TRANSPORT) \
 	      --masters $(MINIDCOS_MASTERS) \
 	      --agents $(MINIDCOS_AGENTS) \

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ dev-stop:
 	    echo "options attempts:3" && \
 	    echo $(shell source /opt/mesosphere/etc/dns_config && \
 	                 echo $${RESOLVERS} | \
-	                 sed -e 's/(^|[,])/\nnameserver /g') \
+	                 sed -e 's/\(^\|[,]\)/\nnameserver /g') \
 	  ) > /etc/resolv.conf
 
 dev-start:


### PR DESCRIPTION
It's a small fix for https://github.com/dcos/dcos-net/pull/116/commits/7e6a5886175598f9c951797a5e2323f967c3fbff#diff-b67911656ef5d18c4ae36cb6741b7965R105. Please also see https://github.com/dcos/dcos-net/pull/116.

#48:
```
$ echo 1.1.1.1,1.0.0.1 | sed -re 's/(^|[,])/\nnameserver /g'

nameserver 1.1.1.1
nameserver 1.0.0.1
```

#116:
```
$ echo 1.1.1.1,1.0.0.1 | sed -e 's/(^|[,])/\nnameserver /g'
1.1.1.1,1.0.0.1
```

#119:
```
$ echo 1.1.1.1,1.0.0.1 | sed -e 's/\(^\|[,]\)/\nnameserver /g'

nameserver 1.1.1.1
nameserver 1.0.0.1
```