### PR TITLE
Fix a race condition in L4LB

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
@@ -95,8 +95,8 @@ skip_kv_event(Event, Ref) ->
 handle_event(#{value := RawVIPs}) ->
     VIPs = process_vips(RawVIPs),
     ok = cleanup_mappings(VIPs),
-    ok = push_dns_records(),
-    dcos_l4lb_mgr:push_vips(VIPs).
+    ok = dcos_l4lb_mgr:push_vips(VIPs),
+    ok = push_dns_records().
 
 -spec(process_vips([{lkey(), [backend()]}]) -> [{key(), [backend()]}]).
 process_vips(VIPs) ->


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS_OSS-4939
DC/OS PR: https://github.com/dcos/dcos/pull/4830

There are three components in VIP configuration:

1. `l4lb.thisdcos.directory` DNS Zone
2. Local routing table
3. IP_VS configuration

It is currently configured exactly in this order. It causes a race condition when DNS name is resolvable, VIP is routable to the loopback interface, but ip_vs configuration is not yet updated. In this case, TCP/UDP client connects to localhost service that is already running on VIP port using VIP address.

Here is how it should work:

1. Remove old unused routes
2. Update IP_VS configuration
3. Add new routes
4. Wait for steps [1-3]
5. Push DNS Zone to erldns cache