### PR TITLE
Fix issue with apt-get on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     machine:
       enabled: true
-      image: circleci/classic:201710-01
+      image: ubuntu-1604:20190301-01
     working_directory: '~/dcos-net'
     environment:
       - OTP_VERSION: "21.3"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,12 +68,13 @@ jobs:
                   sudo apt-get update &&
                   sudo apt-get install -y --no-install-recommend \
                        iproute2 dnsutils ipvsadm &&
-                  break
+                  exit 0
 
                   echo "Retry apt-get"
                   retries=$[$retries-1]
                   sleep $sleep_time
               done
+              exit 1
       - run:
           name: Installing codecov
           command: pip install codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,9 @@
 version: 2
 jobs:
   build:
-    machine: true
+    machine:
+      enabled: true
+      image: circleci/classic:201710-01
     working_directory: '~/dcos-net'
     environment:
       - OTP_VERSION: "21.3"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   build:
     machine:
       enabled: true
-      image: ubuntu-1604:20190301-01
     working_directory: '~/dcos-net'
     environment:
       - OTP_VERSION: "21.3"
@@ -70,6 +69,7 @@ jobs:
                        iproute2 dnsutils ipvsadm &&
                   exit 0
 
+                  ps xua | grep apt
                   echo "Retry apt-get"
                   retries=$[$retries-1]
                   sleep $sleep_time

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,22 @@ jobs:
           name: Installing test dependencies
           command: |
               set -xe
-              sudo apt-get update
-              sudo apt-get install -y --no-install-recommends \
-                  iproute2 dnsutils ipvsadm
+
+              # https://discuss.circleci.com/t/machine-executor-still-running-apt-when-commands-execute/29200/9
+              retries=10
+              sleep_time=2
+              until [ $retries -eq 0 ]
+              do
+
+                  sudo apt-get update &&
+                  sudo apt-get install -y --no-install-recommend \
+                       iproute2 dnsutils ipvsadm &&
+                  break
+
+                  echo "Retry apt-get"
+                  retries=$[$retries-1]
+                  sleep $sleep_time
+              done
       - run:
           name: Installing codecov
           command: pip install codecov


### PR DESCRIPTION
Start hitting this:
![image](https://user-images.githubusercontent.com/10524/55412708-3bd0a500-5568-11e9-90e8-abab8913c333.png)

Issue seems to be the new default image introduced in April 30th.
https://discuss.circleci.com/t/default-machine-executor-image-update/29308

Fix seems to be using a different image:
- [x] failed - circleci/classic:201710-01 (failed)
- [ ] trying: ubuntu-1604:20190301-01
- [ ] next: circleci/classic:201808-01