### PR TITLE
[1.11] Ignore eexist errors in ipset mgr

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_ipset_mgr.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_ipset_mgr.erl
@@ -325,6 +325,10 @@ request(Pid, Command, Flags, Msg) ->
             {ok, Response};
         {ok, Response} ->
             {ok, Response};
+        {error, eexist, _Response} ->
+            % NOTE: some kernel versions ignore a missing `match` flag for
+            % ipset protocol and return an `eexist` error.
+            {ok, []};
         {error, Code, Response} ->
             Error = get_error(Code),
             {error, Error, Response}


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-52780
Original PR: https://github.com/dcos/dcos-net/pull/147

Some kernel versions ignore a missing `match` flag for ipset protocol and return an `eexist` error.

```
$ sudo ipset create -exist dcos-l4lb hash:ip,port counters
ipset v6.29: Set cannot be created: set with the same name already exists
```