### PR TITLE
Prevert dcos_l4lb_network_sup from killing itself

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_network_sup.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_network_sup.erl
@@ -9,7 +9,7 @@ start_link() ->
 
 init([]) ->
     dcos_l4lb_mgr:init_metrics(),
-    {ok, {#{strategy => rest_for_one},
+    {ok, {#{strategy => rest_for_one, intensity => 10000, period => 1},
         [?CHILD(dcos_l4lb_mgr) || dcos_l4lb_config:networking()] ++
         [?CHILD(dcos_l4lb_lashup_vip_listener)]
     }}.


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS_OSS-5011
JIRA: [https://jira.mesosphere.com/browse/DCOS-56615](https://jira.mesosphere.com/browse/DCOS-56615?focusedCommentId=283343#comment-283343)

It's the last supervisor in dcos-net that doesn't have `intensity` option configured.