### PR TITLE
Prune VIPs with no backends

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
@@ -228,27 +228,38 @@ push_vips(LocalVIPs) ->
 generate_ops(LocalVIPs, VIPs) ->
     AgentIP = dcos_net_dist:nodeip(),
     {Ops, LocalVIPs0} =
-        lists:foldl(
-            fun ({{Key, riak_dt_orswot} = LKey, Backends}, {Acc, LVIPs}) ->
-                {LBackends, LVIPs0} = mtake(Key, LVIPs, []),
-                case generate_backend_ops(AgentIP, LBackends, Backends) of
-                    [] -> {Acc, LVIPs0};
-                    Ops -> {[{update, LKey, {update, Ops}}|Acc], LVIPs0}
-                end
-            end, {[], LocalVIPs}, VIPs),
+        lists:foldl(fun (VIP, {Ops, LVIPs}) ->
+            generate_vip_ops(AgentIP, LVIPs, VIP, Ops)
+        end, {[], LocalVIPs}, VIPs),
     maps:fold(fun (Key, Backends, Acc) ->
         LKey = {Key, riak_dt_orswot},
         [{update, LKey, {add_all, Backends}} | Acc]
     end, Ops, LocalVIPs0).
 
--spec(generate_backend_ops(inet:ip4_address(), [backend()], [backend()]) ->
-    [riak_dt_orswot:orswot_op()]).
-generate_backend_ops(AgentIP, LocalBackends, Backends) ->
-    Backends0 = [B || {IP, _Backend} = B <- Backends, IP =:= AgentIP],
-    {Added, Removed} = dcos_net_utils:complement(LocalBackends, Backends0),
+-spec(generate_vip_ops(inet:ip4_address(), #{key() => [backend()]},
+    {lkey(), [backend()]}, [riak_dt_orswot:orswot_op()]) ->
+    {[riak_dt_map:map_field_update()], #{key() => [backend()]}}).
+generate_vip_ops(AgentIP, LocalVIPs, VIP, Ops) ->
+    {{Key, riak_dt_orswot} = LKey, Backends} = VIP,
+    {LocalBackends, LocalVIPs0} = mtake(Key, LocalVIPs, []),
+    {PrevLocalBackends, RemoteBackends} =
+        lists:partition(fun ({IP, _B}) -> IP =:= AgentIP end, Backends),
+    {Added, Removed} =
+        dcos_net_utils:complement(LocalBackends, PrevLocalBackends),
     AddOps = [{add_all, Added} || Added =/= []],
     RemoveOps = [{remove_all, Removed} || Removed =/= []],
-    AddOps ++ RemoveOps.
+    case {LocalBackends, RemoteBackends, AddOps ++ RemoveOps} of
+        {[], [], _BackendOps} ->
+            %% There is no single backend for the VIP in question,
+            %% hence the VIP is to be dropped completely in order
+            %% to avoid unbounded growth of the state and messages
+            %% that are exchanged among dcos-net nodes.
+            {[{remove, LKey} | Ops], LocalVIPs0};
+        {LocalBackends, RemoteBackends, []} ->
+            {Ops, LocalVIPs0};
+        {LocalBackends, RemoteBackends, BackendOps} ->
+            {[{update, LKey, {update, BackendOps}} | Ops], LocalVIPs0}
+    end.
 
 -spec(mtake(Key, Map, Value) -> {Value, Map}
     when Key :: term(), Value :: term(),
@@ -268,23 +279,30 @@ push_ops(Key, Ops) ->
 
 -spec(log_ops([riak_dt_map:map_field_update()]) -> ok).
 log_ops(Ops) ->
-    lists:foreach(fun ({update, {VIPKey, riak_dt_orswot}, VIPOps}) ->
-        log_ops(VIPKey, VIPOps)
-    end, Ops).
+    lists:foreach(
+        fun ({update, {VIPKey, riak_dt_orswot}, VIPOps}) ->
+                log_update_ops(VIPKey, VIPOps);
+            ({remove, {VIPKey, riak_dt_orswot}}) ->
+                log_remove_op(VIPKey)
+        end, Ops).
 
--spec(log_ops(key(), riak_dt_orswot:orswot_op()) -> ok).
-log_ops(Key, {update, Ops}) ->
+-spec(log_update_ops(key(), riak_dt_orswot:orswot_op()) -> ok).
+log_update_ops(Key, {update, Ops}) ->
     lists:foreach(fun (Op) ->
-        log_ops(Key, Op)
+        log_update_ops(Key, Op)
     end, Ops);
-log_ops(Key, {add_all, Backends}) ->
+log_update_ops(Key, {add_all, Backends}) ->
     lists:foreach(fun ({_AgentIP, Backend}) ->
         lager:notice("VIP updated: ~p, added: ~p", [Key, Backend])
     end, Backends);
-log_ops(Key, {remove_all, Backends}) ->
+log_update_ops(Key, {remove_all, Backends}) ->
     lists:foreach(fun ({_AgentIP, Backend}) ->
         lager:notice("VIP updated: ~p, removed: ~p", [Key, Backend])
     end, Backends).
+
+-spec(log_remove_op(key()) -> ok).
+log_remove_op(Key) ->
+    lager:notice("VIP removed: ~p", [Key]).
 
 
 %%%===================================================================

--- a/apps/dcos_l4lb/test/dcos_l4lb_mesos_poller_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_mesos_poller_SUITE.erl
@@ -12,14 +12,16 @@
 
 -export([
     test_lashup/1,
-    test_mesos_portmapping/1
+    test_mesos_portmapping/1,
+    test_app_restart/1
 ]).
 
 
 %% root tests
 all() -> [
     test_lashup,
-    test_mesos_portmapping
+    test_mesos_portmapping,
+    test_app_restart
 ].
 
 init_per_suite(Config) ->
@@ -29,17 +31,12 @@ end_per_suite(Config) ->
     Config.
 
 init_per_testcase(_, Config) ->
+    meck:new(dcos_net_dist, [no_link, passthrough]),
+    meck:expect(dcos_net_dist, nodeip, fun () -> node_ip() end),
     meck:new(dcos_net_mesos_listener, [no_link, passthrough]),
-    meck:expect(dcos_net_mesos_listener, poll, fun meck_mesos_poll/0),
-
     meck:new(dcos_l4lb_mgr, [no_link, passthrough]),
     meck:expect(dcos_l4lb_mgr, local_port_mappings, fun (_) -> ok end),
     meck:expect(dcos_l4lb_mgr, push_vips, fun (_) -> ok end),
-
-    {ok, _} = application:ensure_all_started(dcos_l4lb),
-    meck:wait(dcos_net_mesos_listener, poll, '_', 5000),
-    meck:wait(dcos_l4lb_mgr, local_port_mappings, '_', 100),
-    timer:sleep(100),
     Config.
 
 end_per_testcase(_, _Config) ->
@@ -49,18 +46,31 @@ end_per_testcase(_, _Config) ->
     end || {App, _, _} <- application:which_applications(),
     not lists:member(App, [stdlib, kernel]) ],
     os:cmd("rm -rf Mnesia.*"),
-    meck:unload(dcos_net_mesos_listener),
     meck:unload(dcos_l4lb_mgr),
+    meck:unload(dcos_net_mesos_listener),
+    meck:unload(dcos_net_dist),
     dcos_l4lb_ipset_mgr:cleanup(),
     ok.
 
-meck_mesos_poll() ->
+node_ip() ->
+    {10, 0, 0, 243}.
+
+ensure_l4lb_started() ->
+    {ok, _} = application:ensure_all_started(dcos_l4lb),
+    meck:wait(dcos_net_mesos_listener, poll, '_', 5000),
+    meck:wait(dcos_l4lb_mgr, local_port_mappings, '_', 100),
+    timer:sleep(100).
+
+meck_mesos_poll_no_tasks() ->
+    {ok, #{}}.
+
+meck_mesos_poll_app_task() ->
     {ok, #{
         <<"app.6e53a5c1-1f27-11e6-bc04-4e40412869d8">> => #{
             name => <<"app">>,
             runtime => mesos,
             framework => <<"marathon">>,
-            agent_ip => {10, 0, 0, 243},
+            agent_ip => node_ip(),
             task_ip => [{9, 0, 1, 29}],
             ports => [
                 #{name => <<"http">>, protocol => tcp, host_port => 12049,
@@ -70,11 +80,66 @@ meck_mesos_poll() ->
         }
     }}.
 
+meck_mesos_poll_app_task_after_restart() ->
+    {ok, #{
+        <<"app.b35733e8-8336-4d21-ae60-f3bc4384a93a">> => #{
+            name => <<"app">>,
+            runtime => mesos,
+            framework => <<"marathon">>,
+            agent_ip => node_ip(),
+            task_ip => [{9, 0, 1, 30}],
+            ports => [
+                #{name => <<"http">>, protocol => tcp, host_port => 23176,
+                  port => 80, vip => [<<"merp:5000">>]}
+            ],
+            state => running
+        }
+    }}.
+
 test_lashup(_Config) ->
-    Value = lashup_kv:value(?VIPS_KEY2),
-    [{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12049}}]}] = Value.
+    meck:expect(dcos_net_mesos_listener, poll, fun meck_mesos_poll_app_task/0),
+    ensure_l4lb_started(),
+    Actual = lashup_kv:value(?VIPS_KEY2),
+    ?assertMatch(
+        [{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12049}}]}],
+        Actual).
 
 test_mesos_portmapping(_Config) ->
-    Expected = [{{tcp, 12049}, {{9, 0, 1, 29}, 80}}],
+    meck:expect(dcos_net_mesos_listener, poll, fun meck_mesos_poll_app_task/0),
+    ensure_l4lb_started(),
     Actual = meck:capture(first, dcos_l4lb_mgr, local_port_mappings, '_', 1),
-    ?assertMatch(Expected, Actual).
+    ?assertMatch(
+        [{{tcp, 12049}, {{9, 0, 1, 29}, 80}}],
+        Actual).
+
+test_app_restart(_Config) ->
+    meck:expect(dcos_net_mesos_listener, poll, fun meck_mesos_poll_app_task/0),
+    ensure_l4lb_started(),
+    {ActualPortMappings, ActualVIPs} = retrieve_data(),
+    ?assertMatch([{{tcp, 12049}, {{9, 0, 1, 29}, 80}}],
+        ActualPortMappings),
+    ?assertMatch([{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12049}}]}],
+        ActualVIPs),
+
+    meck:expect(dcos_net_mesos_listener, poll, fun meck_mesos_poll_no_tasks/0),
+    {ActualPortMappings2, ActualVIPs2} = retrieve_data(),
+    ?assertMatch([], ActualPortMappings2),
+    ?assertMatch([], ActualVIPs2),
+
+    meck:expect(dcos_net_mesos_listener, poll,
+        fun meck_mesos_poll_app_task_after_restart/0),
+    {ActualPortMappings3, ActualVIPs3} = retrieve_data(),
+    ?assertMatch([{{tcp, 23176}, {{9, 0, 1, 30}, 80}}],
+        ActualPortMappings3),
+    ?assertMatch([{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 23176}}]}],
+        ActualVIPs3).
+
+retrieve_data() ->
+    meck:reset(dcos_net_mesos_listener),
+    meck:wait(dcos_net_mesos_listener, poll, '_', 5000),
+    meck:wait(dcos_l4lb_mgr, local_port_mappings, '_', 100),
+    timer:sleep(100),
+    PortMappings = meck:capture(
+        last, dcos_l4lb_mgr, local_port_mappings, '_', 1),
+    VIPs = lashup_kv:value(?VIPS_KEY2),
+    {PortMappings, VIPs}.

--- a/config/ct.sys.config
+++ b/config/ct.sys.config
@@ -47,8 +47,22 @@
         {async_threshold, 1000},
         {log_root, "log"},
         {handlers, [
-            {lager_console_backend, [
-                {level, critical}
+            {cth_readable_lager_backend, [
+                {level, debug},
+                {formatter, lager_default_formatter},
+                {formatter_config, [
+                    date, " ",
+                    time, " ",
+                    "[", severity, "] ",
+                     {pid, ""},
+                     {module, [
+                         {pid, ["@"], ""},
+                         module,
+                         {function, [":", function], ""},
+                         {line, [":",line], ""}
+                    ], ""},
+                     " ", message, "\n"
+                ]}
             ]},
             {lager_file_backend, [
                 {file, "error.log"},


### PR DESCRIPTION
A VIP might have no backends if, for instance, a Marathon application is stopped or removed. To prevent the VIP state from ever-growing, such VIPs should be pruned.

One more thing is piggybacked on this PR. `ct.sys.config` is adjusted to have all `lager` logs go to `ct` output files too. This way, each test case report page now contains all relevant logs.

JIRA issue: [DCOS_OSS-5356](https://jira.mesosphere.com/browse/DCOS_OSS-5356)