### PR TITLE
Add support for big sets in the ipset mgr.

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_ipset_mgr.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_ipset_mgr.erl
@@ -114,7 +114,7 @@ handle_cast(_Request, State) ->
     {ok, non_neg_integer()} | {error, atom() | non_neg_integer()}).
 get_protocol_version(Pid) ->
     case request(Pid, protocol, [request], [{protocol, ?IPSET_PROTOCOL}]) of
-        {ok, Response} ->
+        {ok, [{ipset, protocol, _Flags, _Seq, _Pid, {inet, 0, 0, Response}}]} ->
             case get_protocol_versions(Response) of
                 {ok, ?IPSET_PROTOCOL} ->
                     {ok, ?IPSET_PROTOCOL};
@@ -160,7 +160,7 @@ get_protocol_versions(Response) ->
 get_supported_revision(Pid, Type, Family) ->
     Msg = [{protocol, ?IPSET_PROTOCOL}, {typename, Type}, {family, Family}],
     case request(Pid, type, [request], Msg) of
-        {ok, Response} ->
+        {ok, [{ipset, type, _Flags, _Seq, _Pid, {inet, 0, 0, Response}}]} ->
             case lists:keyfind(revision, 1, Response) of
                 {revision, Revision} -> {ok, Revision};
                 false -> {error, not_found}
@@ -291,18 +291,25 @@ get_entries(Pid, Name) ->
     Msg = [{protocol, ?IPSET_PROTOCOL}, {setname, Name}],
     case request(Pid, list, [match, root, ack, request], Msg) of
         {ok, Response} ->
-            {adt, ADT} = lists:keyfind(adt, 1, Response),
-            {ok, lists:map(fun ({data, Data}) ->
-                {ip, [{_Family, IP}]} = lists:keyfind(ip, 1, Data),
-                {port, Port} = lists:keyfind(port, 1, Data),
-                {proto, Protocol} = lists:keyfind(proto, 1, Data),
-                {Protocol, IP, Port}
-            end, ADT)};
+            {ok, parse_entries(Response)};
         {error, enoent, _Response} ->
             {ok, []};
         {error, Error, _Response} ->
             {error, Error}
     end.
+
+-spec(parse_entries(Response :: term()) -> [entry()]).
+parse_entries(Response) ->
+    lists:flatmap(
+        fun ({ipset, list, _Flags, _Seq, _Pid, {inet, 0, 0, Info}}) ->
+            {adt, ADT} = lists:keyfind(adt, 1, Info),
+            lists:map(fun ({data, Data}) ->
+                {ip, [{_Family, IP}]} = lists:keyfind(ip, 1, Data),
+                {port, Port} = lists:keyfind(port, 1, Data),
+                {proto, Protocol} = lists:keyfind(proto, 1, Data),
+                {Protocol, IP, Port}
+            end, ADT)
+        end, Response).
 
 %%%===================================================================
 %%% Internal functions
@@ -313,8 +320,6 @@ get_entries(Pid, Name) ->
 request(Pid, Command, Flags, Msg) ->
     Args = [Pid, ?NETLINK_NETFILTER, ipset, Command, Flags, {inet, 0, 0, Msg}],
     case apply(gen_netlink_client, request, Args) of
-        {ok, [{ipset, Command, _Flags, _Seq, _Pid, {inet, 0, 0, Response}}]} ->
-            {ok, Response};
         {ok, Response} ->
             {ok, Response};
         {error, eexist, _Response} ->

--- a/apps/dcos_l4lb/test/dcos_l4lb_ipset_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_ipset_SUITE.erl
@@ -1,0 +1,67 @@
+-module(dcos_l4lb_ipset_SUITE).
+-export([
+    all/0,
+    init_per_testcase/2, end_per_testcase/2,
+    test_huge/1
+]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+all() ->
+    [test_huge].
+
+init_per_testcase(TestCase, Config) ->
+    Uid = list_to_integer(string:strip(os:cmd("id -u"), right, $\n)),
+    init_per_testcase(Uid, TestCase, Config).
+
+init_per_testcase(0, _TestCase, Config) ->
+    Config;
+init_per_testcase(_, _, _) ->
+    {skip, "Not running as root"}.
+
+end_per_testcase(_, _Config) ->
+    dcos_l4lb_ipset_mgr:cleanup().
+
+test_huge(_Config) ->
+    % NOTE: it's not a performance test, ipset netlink protocol split a big
+    % hash into several netlink messages. The test checks that the ipset
+    % manager can handle this case.
+
+    % Generating 32768 entries.
+    Range = lists:seq(1, 8),
+    IPs = [{A, B, C, D} || A <- Range, B <- Range, C <- Range, D <- Range],
+    Entries = [{tcp, IP, Port} || IP <- IPs, Port <- Range],
+
+    % Starting the ipset manager.
+    {ok, Pid} = dcos_l4lb_ipset_mgr:start_link(),
+
+    % Adding entries.
+    ok = add_entries(Pid, Entries),
+    ?assertEqual(
+        lists:sort(Entries),
+        lists:sort(get_entries(Pid))),
+
+    % Removing entries.
+    ok = remove_entries(Pid, Entries),
+    ?assertEqual([], get_entries(Pid)),
+
+    % Stopping the ipset manager.
+    unlink(Pid),
+    exit(Pid, kill).
+
+%%%===================================================================
+%%% Call functions
+%%%===================================================================
+
+% NOTE: On slow CI nodes, it can take a bit longer than default 5 seconds to
+% add, remove, or get ipset entries. So for test purposes, here are functions
+% that don't have timeouts. The functions don't require prometheus running.
+
+get_entries(Pid) ->
+    gen_server:call(Pid, get_entries, infinity).
+
+add_entries(Pid, Entries) ->
+    gen_server:call(Pid, {add_entries, Entries}, infinity).
+
+remove_entries(Pid, Entries) ->
+    gen_server:call(Pid, {remove_entries, Entries}, infinity).


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/COPS-5229

IPSet Netlink Protocol splits big sets into several netlink messages.
First message contains all metadata about a set, but just a part of
all entries. Following messages contains only remaining entries.