### PR TITLE
[1.11] Get ipset entries using existing process

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_mgr.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mgr.erl
@@ -213,7 +213,7 @@ do_reconcile(VIPs, State0 = #state{route_mgr = RouteMgr, ipset_mgr = IPSetMgr, n
     State1 = State0#state{last_received_vips = VIPs0, last_configured_vips = VIPs1, routes = Routes},
 
     Keys = ordsets:from_list([Key || {Key, _Backends} <- VIPs1]),
-    InstalledKeys = dcos_l4lb_ipset_mgr:get_entries(),
+    InstalledKeys = dcos_l4lb_ipset_mgr:get_entries(IPSetMgr),
     KeysToAdd = ordsets:subtract(Keys, InstalledKeys),
     KeysToDel = ordsets:subtract(InstalledKeys, Keys),
 


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/COPS-5260

It's an minor issue only with DC/OS 1.11 cuz `dcos_l4lb_mgr` has been re-written in DC/OS 1.12.

dcos_l4lb_ipset_mgr:get_entries/0 is a debug api. It spawns a new process, get ipset entires, and terminates it. If ipset mgr is disabled the process returns an empty list, but also tries to clean
up iptables and ipsets. Some error messages will be printed every 30 seconds in that case. The issue doesn't really affect anything.