### PR TITLE
Make runbook a bit more sysadmin friendly

### DIFF
--- a/runbook/net-runbook.sh
+++ b/runbook/net-runbook.sh
@@ -399,20 +399,24 @@ dns-data() {
 
 # dig <yourapp>.<yourframework>.mesos @127.0.0.1 -p 61053
 
-mkdir "$DATA_DIR"
+main() {
+  mkdir "$DATA_DIR"
 
-dcos-version
-os-data
-docker-version
-logs
-dcos-configs
-sockets
-mesos-state
-l4lb-data
-overlay-data
-docker-networks
-dns-data
+  dcos-version
+  os-data
+  docker-version
+  logs
+  dcos-configs
+  sockets
+  mesos-state
+  l4lb-data
+  overlay-data
+  docker-networks
+  dns-data
 
-chmod 644 "$DATA_DIR"/*
-tar czf "$DATA_DIR.tar.gz" "$DATA_DIR"
-rm -Rf "$DATA_DIR"
+  chmod 644 "$DATA_DIR"/*
+  tar czf "$DATA_DIR.tar.gz" "$DATA_DIR"
+  rm -Rf "$DATA_DIR"
+}
+
+main


### PR DESCRIPTION
I've been using the runbook to automate the gathering of data while troubleshooting various issues and reproducing test failures. I've updated it accordingly to:

1. Pass [`shellcheck`](https://github.com/koalaman/shellcheck) linting
1. Use `dig` from the `net-toolbox` docker image
1. Wrap the main logic into a function that gets called at the end to ensure it is executed atomiclly.