### PR TITLE
Handle TASK_KILLING state for loadbalancing

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
@@ -116,7 +116,7 @@ process_vip(Key, BEs) ->
 
 -spec(categorize_backends([backend()]) -> [{family(), [backend()]}]).
 categorize_backends(BEs) ->
-    lists:foldl(fun ({_AgentIP, {IP, _Port}}=BE, Acc) ->
+    lists:foldl(fun ({_AgentIP, {IP, _Port, _Weight}}=BE, Acc) ->
         Family = dcos_l4lb_app:family(IP),
         orddict:append(Family, BE, Acc)
     end, orddict:new(), BEs).

--- a/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
@@ -136,6 +136,11 @@ is_healthy(_TaskId, Task) ->
 -spec(is_healthy(task()) -> boolean()).
 is_healthy(#{healthy := IsHealthy, state := running}) ->
     IsHealthy;
+% NOTE(jkoelker): when the state is `killing` we specifically ignore health
+%                 checks, since mesos stops checking when the task transitions
+%                 to `killing`.
+is_healthy(#{state := killing}) ->
+    true;
 is_healthy(#{state := running}) ->
     true;
 is_healthy(_Task) ->

--- a/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
@@ -21,7 +21,7 @@
     handle_cast/2, handle_info/2, handle_continue/2]).
 
 -export_type([named_vip/0, vip/0, protocol/0,
-    key/0, lkey/0, backend/0]).
+    key/0, lkey/0, backend/0, backend_weight/0]).
 
 -record(state, {
     backoff :: backoff:backoff(),
@@ -39,8 +39,11 @@
 -type lkey() :: {key(), riak_dt_orswot}.
 -type backend() :: {
     AgentIP :: inet:ip4_address(),
-    {BackendIP :: inet:ip_address(), BackendPort :: inet:port_number() }
+    {BackendIP :: inet:ip_address(),
+     BackendPort :: inet:port_number(),
+     BackendWeight :: backend_weight() }
 }.
+-type backend_weight() :: 0..65535.
 
 -spec(start_link() ->
     {ok, Pid :: pid()} | ignore | {error, Reason :: term()}).
@@ -210,15 +213,24 @@ key(Task, PortObj, VIPLabel) ->
 backends(Key, Task, PortObj) ->
     IsIPv6Enabled = dcos_l4lb_config:ipv6_enabled(),
     AgentIP = maps:get(agent_ip, Task),
+    Weight = get_weight(Task),
     case maps:find(host_port, PortObj) of
         error ->
             Port = maps:get(port, PortObj),
-            [ {AgentIP, {TaskIP, Port}}
+            [ {AgentIP, {TaskIP, Port, Weight}}
             || TaskIP <- maps:get(task_ip, Task),
                validate_backend_ip(IsIPv6Enabled, Key, TaskIP) ];
         {ok, HostPort} ->
-            [{AgentIP, {AgentIP, HostPort}}]
+            [{AgentIP, {AgentIP, HostPort, Weight}}]
     end.
+
+-spec(get_weight(task()) -> backend_weight()).
+get_weight(#{state := killing}) ->
+    0;
+get_weight(#{state := running}) ->
+    1;
+get_weight(_Task) ->
+    0.
 
 -spec(validate_backend_ip(boolean(), key(), inet:ip_address()) -> boolean()).
 validate_backend_ip(true, {_Protocol, {name, _Name}, _VIPPort}, _TaskIP) ->

--- a/apps/dcos_l4lb/test/dcos_l4lb_ipvs_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_ipvs_SUITE.erl
@@ -90,7 +90,7 @@ webserver(Pid, AgentIP) ->
     Info = httpd:info(Pid),
     Port = proplists:get_value(port, Info),
     IP = proplists:get_value(bind_address, Info),
-    {AgentIP, {IP, Port}}.
+    {AgentIP, {IP, Port, 1}}.
 
 add_webserver(VIP, WebServer) ->
     % inject an update for this vip

--- a/apps/dcos_l4lb/test/dcos_l4lb_lashup_vip_listener_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_lashup_vip_listener_SUITE.erl
@@ -47,8 +47,8 @@ end_per_testcase(_, _Config) ->
 
 -define(LKEY(K), {{tcp, K, 80}, riak_dt_orswot}).
 -define(LKEY(L, F), ?LKEY({name, {L, F}})).
--define(BE4, {{1, 2, 3, 4}, {{1, 2, 3, 4}, 80}}).
--define(BE6, {{1, 2, 3, 4}, {{1, 0, 0, 0, 0, 0, 0, 1}, 80}}).
+-define(BE4, {{1, 2, 3, 4}, {{1, 2, 3, 4}, 80, 1}}).
+-define(BE6, {{1, 2, 3, 4}, {{1, 0, 0, 0, 0, 0, 0, 1}, 80, 1}}).
 
 lookup_vips(_Config) ->
     lashup_kv:request_op(?VIPS_KEY2, {update, [

--- a/apps/dcos_net/src/dcos_net_mesos_listener.erl
+++ b/apps/dcos_net/src/dcos_net_mesos_listener.erl
@@ -32,7 +32,7 @@
     ports => [task_port()]
 }.
 -type runtime() :: docker | mesos | unknown.
--type task_state() :: preparing | running | terminal.
+-type task_state() :: preparing | running | killing | terminal.
 -type task_port() :: #{
     name => binary(),
     host_port => inet:port_number(),
@@ -536,6 +536,8 @@ handle_task_state(TaskObj, _Task) ->
             terminal;
         <<"TASK_RUNNING">> ->
             running;
+        <<"TASK_KILLING">> ->
+            killing;
         _TaskState ->
             preparing
     end.

--- a/apps/dcos_rest/src/dcos_rest_vips_handler.erl
+++ b/apps/dcos_rest/src/dcos_rest_vips_handler.erl
@@ -51,7 +51,7 @@ vip(Protocol, FullName, Port) ->
     PortBin = integer_to_binary(Port),
     {<<FullName/binary, ":", PortBin/binary>>, Protocol}.
 
-backend({_AgentIP, {IP, Port}}) ->
+backend({_AgentIP, {IP, Port, _Weight}}) ->
     #{
         ip => ip(IP),
         port => Port

--- a/rebar.config
+++ b/rebar.config
@@ -182,7 +182,7 @@
         rules => [
             {elvis_style, max_function_length, #{max_length => 30}},
             {elvis_style, no_spec_with_records},
-            {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
+            {elvis_style, dont_repeat_yourself, #{min_complexity => 21}},
             {elvis_style, no_behavior_info},
             {elvis_style, used_ignored_variable},
             {elvis_style, nesting_level, #{level => 3}},


### PR DESCRIPTION
Set the weight to `0` for tasks in state `TASK_KILLING`. This allows existing connections to gracefully terminate while not accepting new connections to a backend.

JIRA: https://jira.d2iq.com/browse/COPS-5602
DCOS PR: https://github.com/dcos/dcos/pull/6907
