### PR TITLE
D2IQ-61077: Adjust l4lb task state handling

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_ipvs_mgr.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_ipvs_mgr.erl
@@ -15,7 +15,7 @@
 -export([start_link/0]).
 
 -export([get_dests/3,
-         add_dest/7,
+         add_dest/8,
          remove_dest/7,
          get_services/2,
          add_service/5,
@@ -75,6 +75,8 @@
 -type dest() :: term().
 -export_type([service/0, dest/0]).
 
+-type backend_weight() :: dcos_l4lb_mesos_poller:backend_weight().
+
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -107,9 +109,10 @@ remove_dest(Pid, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace) 
 
 -spec(add_dest(Pid :: pid(), ServiceIP :: inet:ip_address(), ServicePort :: inet:port_number(),
                DestIP :: inet:ip_address(), DestPort :: inet:port_number(),
-               Protocol :: protocol(), Namespace :: term()) -> ok | error).
-add_dest(Pid, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace) ->
-    gen_server:call(Pid, {add_dest, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace}).
+               Protocol :: protocol(), Namespace :: term(),
+               Weight :: backend_weight()) -> ok | error).
+add_dest(Pid, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, Weight) ->
+    gen_server:call(Pid, {add_dest, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, Weight}).
 
 add_netns(Pid, UpdateValue) ->
     gen_server:call(Pid, {add_netns, UpdateValue}).
@@ -144,8 +147,8 @@ handle_call({remove_service, IP, Port, Protocol, Namespace}, _From, State) ->
 handle_call({get_dests, Service, Namespace}, _From, State) ->
     Reply = handle_get_dests(Service, Namespace, State),
     {reply, Reply, State};
-handle_call({add_dest, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace}, _From, State) ->
-    Reply = handle_add_dest(ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, State),
+handle_call({add_dest, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, Weight}, _From, State) ->
+    Reply = handle_add_dest(ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, State, Weight),
     {reply, Reply, State};
 handle_call({remove_dest, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace}, _From, State) ->
     Reply = handle_remove_dest(ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, State),
@@ -267,16 +270,17 @@ handle_get_dests(Service, Namespace, #state{netns = NetnsMap, family = Family}) 
 
 -spec(handle_add_dest(ServiceIP :: inet:ip_address(), ServicePort :: inet:port_number(),
                       DestIP :: inet:ip_address(), DestPort :: inet:port_number(),
-                      Protocol :: protocol(), Namespace :: term(), State :: state()) -> ok | error).
+                      Protocol :: protocol(), Namespace :: term(), State :: state(),
+                      Weight :: backend_weight()) -> ok | error).
 handle_add_dest(ServiceIP, ServicePort, DestIP, DestPort, Protocol,
-                Namespace, #state{netns = NetnsMap, family = Family}) ->
+                Namespace, #state{netns = NetnsMap, family = Family}, Weight) ->
     Pid = maps:get(Namespace, NetnsMap),
     Protocol1 = netlink_codec:protocol_to_int(Protocol),
     Service = ip_to_address(ServiceIP) ++ [{port, ServicePort}, {protocol, Protocol1}],
-    handle_add_dest(Pid, Service, DestIP, DestPort, Family).
+    handle_add_dest(Pid, Service, DestIP, DestPort, Family, Weight).
 
-handle_add_dest(Pid, Service, IP, Port, Family) ->
-    Base = [{fwd_method, ?IP_VS_CONN_F_MASQ}, {weight, 1}, {u_threshold, 0}, {l_threshold, 0}],
+handle_add_dest(Pid, Service, IP, Port, Family, Weight) ->
+    Base = [{fwd_method, ?IP_VS_CONN_F_MASQ}, {weight, Weight}, {u_threshold, 0}, {l_threshold, 0}],
     Dest = [{port, Port}] ++ Base ++ ip_to_address(IP),
     lager:info("Adding backend ~p to service ~p~n", [{IP, Port}, Service]),
     Msg = #new_dest{request = [{dest, Dest}, {service, Service}]},

--- a/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
@@ -120,7 +120,7 @@ process_vip(Key, BEs) ->
 
 -spec(categorize_backends([backend()]) -> [{family(), [backend()]}]).
 categorize_backends(BEs) ->
-    lists:foldl(fun ({_AgentIP, {IP, _Port}}=BE, Acc) ->
+    lists:foldl(fun ({_AgentIP, {IP, _Port, _Weight}}=BE, Acc) ->
         Family = dcos_l4lb_app:family(IP),
         orddict:append(Family, BE, Acc)
     end, orddict:new(), BEs).

--- a/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
@@ -114,6 +114,11 @@ is_healthy(_TaskId, Task) ->
 -spec(is_healthy(task()) -> boolean()).
 is_healthy(#{healthy := IsHealthy, state := running}) ->
     IsHealthy;
+% NOTE(jkoelker): when the state is `killing` we specifically ignore health
+%                 checks, since mesos stops checking when the task transitions
+%                 to `killing`.
+is_healthy(#{state := killing}) ->
+    true;
 is_healthy(#{state := running}) ->
     true;
 is_healthy(_Task) ->

--- a/apps/dcos_l4lb/src/dcos_l4lb_mgr.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mgr.erl
@@ -390,11 +390,11 @@ apply_vips_diff(IPVSMgr, Namespace, {ToAdd, ToDel, ToMod}) ->
 -spec(vip_add(pid(), namespace(), {key(), [ipport()]}) -> ok).
 vip_add(IPVSMgr, Namespace, {{Protocol, IP, Port}, BEs}) ->
     dcos_l4lb_ipvs_mgr:add_service(IPVSMgr, IP, Port, Protocol, Namespace),
-    lists:foreach(fun ({BEIP, BEPort}) ->
+    lists:foreach(fun ({BEIP, BEPort, BEWeight}) ->
         dcos_l4lb_ipvs_mgr:add_dest(
             IPVSMgr, IP, Port,
             BEIP, BEPort,
-            Protocol, Namespace)
+            Protocol, Namespace, BEWeight)
     end, BEs).
 
 -spec(vip_del(pid(), namespace(), {key(), [ipport()]}) -> ok).
@@ -403,13 +403,13 @@ vip_del(IPVSMgr, Namespace, {{Protocol, IP, Port}, _BEs}) ->
 
 -spec(vip_mod(pid(), namespace(), {key(), [ipport()], [ipport()]}) -> ok).
 vip_mod(IPVSMgr, Namespace, {{Protocol, IP, Port}, ToAdd, ToDel}) ->
-    lists:foreach(fun ({BEIP, BEPort}) ->
+    lists:foreach(fun ({BEIP, BEPort, BEWeight}) ->
         dcos_l4lb_ipvs_mgr:add_dest(
             IPVSMgr, IP, Port,
             BEIP, BEPort,
-            Protocol, Namespace)
+            Protocol, Namespace, BEWeight)
     end, ToAdd),
-    lists:foreach(fun ({BEIP, BEPort}) ->
+    lists:foreach(fun ({BEIP, BEPort, _BEWeight}) ->
         dcos_l4lb_ipvs_mgr:remove_dest(
             IPVSMgr, IP, Port,
             BEIP, BEPort,
@@ -620,13 +620,13 @@ vips_port_mappings(VIPs) ->
          Container :: {inet:ip_address(), inet:port_number()}).
 bes_port_mappings(PMs, Protocol, AgentIP, BEs) ->
     lists:map(
-        fun ({BEAgentIP, {BEIP, BEPort}}) when BEIP =:= AgentIP ->
+        fun ({BEAgentIP, {BEIP, BEPort, Weight}}) when BEIP =:= AgentIP ->
                 case maps:find({Protocol, BEPort}, PMs) of
-                    {ok, {IP, Port}} -> {BEAgentIP, {IP, Port}};
-                    error -> {BEAgentIP, {BEIP, BEPort}}
+                    {ok, {IP, Port}} -> {BEAgentIP, {IP, Port, Weight}};
+                    error -> {BEAgentIP, {BEIP, BEPort, Weight}}
                 end;
-            ({BEAgentIP, {BEIP, BEPort}}) ->
-                {BEAgentIP, {BEIP, BEPort}}
+            ({BEAgentIP, {BEIP, BEPort, Weight}}) ->
+                {BEAgentIP, {BEIP, BEPort, Weight}}
         end, BEs).
 
 %%%===================================================================

--- a/apps/dcos_l4lb/test/dcos_l4lb_ipvs_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_ipvs_SUITE.erl
@@ -90,7 +90,7 @@ webserver(Pid, AgentIP) ->
     Info = httpd:info(Pid),
     Port = proplists:get_value(port, Info),
     IP = proplists:get_value(bind_address, Info),
-    {AgentIP, {IP, Port}}.
+    {AgentIP, {IP, Port, 1}}.
 
 add_webserver(VIP, WebServer) ->
     % inject an update for this vip

--- a/apps/dcos_l4lb/test/dcos_l4lb_lashup_vip_listener_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_lashup_vip_listener_SUITE.erl
@@ -47,8 +47,8 @@ end_per_testcase(_, _Config) ->
 
 -define(LKEY(K), {{tcp, K, 80}, riak_dt_orswot}).
 -define(LKEY(L, F), ?LKEY({name, {L, F}})).
--define(BE4, {{1, 2, 3, 4}, {{1, 2, 3, 4}, 80}}).
--define(BE6, {{1, 2, 3, 4}, {{1, 0, 0, 0, 0, 0, 0, 1}, 80}}).
+-define(BE4, {{1, 2, 3, 4}, {{1, 2, 3, 4}, 80, 1}}).
+-define(BE6, {{1, 2, 3, 4}, {{1, 0, 0, 0, 0, 0, 0, 1}, 80, 1}}).
 
 lookup_vips(_Config) ->
     lashup_kv:request_op(?VIPS_KEY2, {update, [

--- a/apps/dcos_l4lb/test/dcos_l4lb_mesos_poller_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_mesos_poller_SUITE.erl
@@ -14,7 +14,8 @@
     test_lashup/1,
     test_mesos_portmapping/1,
     test_app_restart/1,
-    test_task_killing/1
+    test_task_killing/1,
+    test_task_unhealthy/1
 ]).
 
 
@@ -23,7 +24,8 @@ all() -> [
     test_lashup,
     test_mesos_portmapping,
     test_app_restart,
-    test_task_killing
+    test_task_killing,
+    test_task_unhealthy
 ].
 
 init_per_suite(Config) ->
@@ -97,6 +99,23 @@ meck_mesos_poll_app_task_killing() ->
         }
     }}.
 
+meck_mesos_poll_app_task_unhealthy() ->
+    {ok, #{
+        <<"app.6e53a5c1-1f27-11e6-bc04-4e40412869d8">> => #{
+            name => <<"app">>,
+            runtime => mesos,
+            framework => <<"marathon">>,
+            agent_ip => node_ip(),
+            task_ip => [{9, 0, 1, 29}],
+            ports => [
+                #{name => <<"http">>, protocol => tcp, host_port => 12050,
+                  port => 80, vip => [<<"merp:5000">>]}
+            ],
+            state => running,
+            healthy => false
+        }
+    }}.
+
 meck_mesos_poll_app_task_after_restart() ->
     {ok, #{
         <<"app.b35733e8-8336-4d21-ae60-f3bc4384a93a">> => #{
@@ -157,6 +176,14 @@ test_task_killing(_Config) ->
     Actual = lashup_kv:value(?VIPS_KEY2),
     ?assertMatch(
         [{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12049, 0}}]}],
+        Actual).
+
+test_task_unhealthy(_Config) ->
+    meck:expect(dcos_net_mesos_listener, poll, fun meck_mesos_poll_app_task_unhealthy/0),
+    ensure_l4lb_started(),
+    Actual = lashup_kv:value(?VIPS_KEY2),
+    ?assertMatch(
+        [{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12050, 0}}]}],
         Actual).
 
 retrieve_data() ->

--- a/apps/dcos_l4lb/test/dcos_l4lb_mesos_poller_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_mesos_poller_SUITE.erl
@@ -13,7 +13,8 @@
 -export([
     test_lashup/1,
     test_mesos_portmapping/1,
-    test_app_restart/1
+    test_app_restart/1,
+    test_task_killing/1
 ]).
 
 
@@ -21,7 +22,8 @@
 all() -> [
     test_lashup,
     test_mesos_portmapping,
-    test_app_restart
+    test_app_restart,
+    test_task_killing
 ].
 
 init_per_suite(Config) ->
@@ -79,6 +81,22 @@ meck_mesos_poll_app_task() ->
         }
     }}.
 
+meck_mesos_poll_app_task_killing() ->
+    {ok, #{
+        <<"app.22a97c91-8a25-43ed-8195-e20938687ec3">> => #{
+            name => <<"app">>,
+            runtime => mesos,
+            framework => <<"marathon">>,
+            agent_ip => node_ip(),
+            task_ip => [{9, 0, 1, 29}],
+            ports => [
+                #{name => <<"http">>, protocol => tcp, host_port => 12049,
+                  port => 80, vip => [<<"merp:5000">>]}
+            ],
+            state => killing
+        }
+    }}.
+
 meck_mesos_poll_app_task_after_restart() ->
     {ok, #{
         <<"app.b35733e8-8336-4d21-ae60-f3bc4384a93a">> => #{
@@ -100,7 +118,7 @@ test_lashup(_Config) ->
     ensure_l4lb_started(),
     Actual = lashup_kv:value(?VIPS_KEY2),
     ?assertMatch(
-        [{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12049}}]}],
+        [{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12049, 1}}]}],
         Actual).
 
 test_mesos_portmapping(_Config) ->
@@ -117,7 +135,7 @@ test_app_restart(_Config) ->
     {ActualPortMappings, ActualVIPs} = retrieve_data(),
     ?assertMatch([{{tcp, 12049}, {{9, 0, 1, 29}, 80}}],
         ActualPortMappings),
-    ?assertMatch([{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12049}}]}],
+    ?assertMatch([{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12049, 1}}]}],
         ActualVIPs),
 
     meck:expect(dcos_net_mesos_listener, poll, fun meck_mesos_poll_no_tasks/0),
@@ -130,8 +148,16 @@ test_app_restart(_Config) ->
     {ActualPortMappings3, ActualVIPs3} = retrieve_data(),
     ?assertMatch([{{tcp, 23176}, {{9, 0, 1, 30}, 80}}],
         ActualPortMappings3),
-    ?assertMatch([{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 23176}}]}],
+    ?assertMatch([{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 23176, 1}}]}],
         ActualVIPs3).
+
+test_task_killing(_Config) ->
+    meck:expect(dcos_net_mesos_listener, poll, fun meck_mesos_poll_app_task_killing/0),
+    ensure_l4lb_started(),
+    Actual = lashup_kv:value(?VIPS_KEY2),
+    ?assertMatch(
+        [{_, [{{10, 0, 0, 243}, {{10, 0, 0, 243}, 12049, 0}}]}],
+        Actual).
 
 retrieve_data() ->
     meck:reset(dcos_net_mesos_listener),

--- a/apps/dcos_net/src/dcos_net_mesos_listener.erl
+++ b/apps/dcos_net/src/dcos_net_mesos_listener.erl
@@ -30,7 +30,7 @@
     ports => [task_port()]
 }.
 -type runtime() :: docker | mesos | unknown.
--type task_state() :: preparing | running | terminal.
+-type task_state() :: preparing | running | killing | terminal.
 -type task_port() :: #{
     name => binary(),
     host_port => inet:port_number(),
@@ -441,6 +441,8 @@ handle_task_state(TaskObj, _Task) ->
             terminal;
         <<"TASK_RUNNING">> ->
             running;
+        <<"TASK_KILLING">> ->
+            killing;
         _TaskState ->
             preparing
     end.

--- a/apps/dcos_rest/src/dcos_rest_vips_handler.erl
+++ b/apps/dcos_rest/src/dcos_rest_vips_handler.erl
@@ -51,7 +51,7 @@ vip(Protocol, FullName, Port) ->
     PortBin = integer_to_binary(Port),
     {<<FullName/binary, ":", PortBin/binary>>, Protocol}.
 
-backend({_AgentIP, {IP, Port}}) ->
+backend({_AgentIP, {IP, Port, _Weight}}) ->
     #{
         ip => ip(IP),
         port => Port

--- a/rebar.config
+++ b/rebar.config
@@ -187,7 +187,7 @@
         rules => [
             {elvis_style, max_function_length, #{max_length => 30}},
             {elvis_style, no_spec_with_records},
-            {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
+            {elvis_style, dont_repeat_yourself, #{min_complexity => 21}},
             {elvis_style, no_behavior_info},
             {elvis_style, used_ignored_variable},
             {elvis_style, nesting_level, #{level => 3}},


### PR DESCRIPTION
---
↩️  _This PR back-ports a fix introduced with #193 to 1.13.x._

---

Set the weight to 0 for unhealthy tasks and tasks entering `TASK_KILLING`. This allows existing connections to gracefully terminate while not accepting new connections to a backend.