### PR TITLE
D2IQ-61077: Adjust l4lb task state handling

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_ipvs_mgr.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_ipvs_mgr.erl
@@ -275,7 +275,7 @@ handle_add_dest(ServiceIP, ServicePort, DestIP, DestPort, Protocol,
 handle_add_dest(Pid, Service, IP, Port, Family, Weight) ->
     Base = [{fwd_method, ?IP_VS_CONN_F_MASQ}, {weight, Weight}, {u_threshold, 0}, {l_threshold, 0}],
     Dest = [{port, Port}] ++ Base ++ ip_to_address(IP),
-    ?LOG_INFO("Adding backend ~p to service ~p~n", [{IP, Port}, Service]),
+    ?LOG_INFO("Adding backend ~p to service ~p~n", [{IP, Port, Weight}, Service]),
     Msg = #new_dest{request = [{dest, Dest}, {service, Service}]},
     case gen_netlink_client:request(Pid, Family, ipvs, [], Msg) of
         {ok, _} -> ok;

--- a/apps/dcos_l4lb/src/dcos_l4lb_ipvs_mgr.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_ipvs_mgr.erl
@@ -16,6 +16,7 @@
 
 -export([get_dests/3,
          add_dest/8,
+         mod_dest/8,
          remove_dest/7,
          get_services/2,
          add_service/5,
@@ -113,6 +114,13 @@ remove_dest(Pid, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace) 
 add_dest(Pid, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, Weight) ->
     call(Pid, {add_dest, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, Weight}).
 
+-spec(mod_dest(Pid :: pid(), ServiceIP :: inet:ip_address(), ServicePort :: inet:port_number(),
+               DestIP :: inet:ip_address(), DestPort :: inet:port_number(),
+               Protocol :: protocol(), Namespace :: term(),
+               Weight :: backend_weight()) -> ok | error).
+mod_dest(Pid, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, Weight) ->
+    gen_server:call(Pid, {mod_dest, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, Weight}).
+
 add_netns(Pid, UpdateValue) ->
     call(Pid, {add_netns, UpdateValue}).
 
@@ -148,6 +156,9 @@ handle_call({get_dests, Service, Namespace}, _From, State) ->
     {reply, Reply, State};
 handle_call({add_dest, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, Weight}, _From, State) ->
     Reply = handle_add_dest(ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, State, Weight),
+    {reply, Reply, State};
+handle_call({mod_dest, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, Weight}, _From, State) ->
+    Reply = handle_mod_dest(ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, State, Weight),
     {reply, Reply, State};
 handle_call({remove_dest, ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace}, _From, State) ->
     Reply = handle_remove_dest(ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace, State),
@@ -260,6 +271,24 @@ handle_get_dests(Service, Namespace, #state{netns = NetnsMap, family = Family}) 
     {ok, Replies} = gen_netlink_client:request(Pid, Family, ipvs, [root, match], Message),
     [proplists:get_value(dest, MaybeDest) || #netlink{msg = #new_dest{request = MaybeDest}} <- Replies,
         proplists:is_defined(dest, MaybeDest)].
+
+-spec(handle_mod_dest(ServiceIP :: inet:ip_address(), ServicePort :: inet:port_number(),
+                      DestIP :: inet:ip_address(), DestPort :: inet:port_number(),
+                      Protocol :: protocol(), Namespace :: term(), State :: state(),
+                      Weight :: backend_weight()) -> ok | error).
+handle_mod_dest(ServiceIP, ServicePort, DestIP, DestPort, Protocol,
+                Namespace, #state{netns = NetnsMap, family = Family}, Weight) ->
+    Pid = maps:get(Namespace, NetnsMap),
+    Protocol1 = netlink_codec:protocol_to_int(Protocol),
+    Service = ip_to_address(ServiceIP) ++ [{port, ServicePort}, {protocol, Protocol1}],
+    Base = [{fwd_method, ?IP_VS_CONN_F_MASQ}, {weight, Weight}, {u_threshold, 0}, {l_threshold, 0}],
+    Dest = [{port, DestPort}] ++ Base ++ ip_to_address(DestIP),
+    ?LOG_INFO("Modifying backend ~p for service ~p~n", [{DestIP, DestPort, Weight}, Service]),
+    Msg = #set_dest{request = [{dest, Dest}, {service, Service}]},
+    case gen_netlink_client:request(Pid, Family, ipvs, [], Msg) of
+        {ok, _} -> ok;
+        _ -> error
+    end.
 
 -spec(handle_add_dest(ServiceIP :: inet:ip_address(), ServicePort :: inet:port_number(),
                       DestIP :: inet:ip_address(), DestPort :: inet:port_number(),

--- a/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
@@ -116,7 +116,7 @@ process_vip(Key, BEs) ->
 
 -spec(categorize_backends([backend()]) -> [{family(), [backend()]}]).
 categorize_backends(BEs) ->
-    lists:foldl(fun ({_AgentIP, {IP, _Port}}=BE, Acc) ->
+    lists:foldl(fun ({_AgentIP, {IP, _Port, _Weight}}=BE, Acc) ->
         Family = dcos_l4lb_app:family(IP),
         orddict:append(Family, BE, Acc)
     end, orddict:new(), BEs).

--- a/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
@@ -116,9 +116,15 @@ process_vip(Key, BEs) ->
 
 -spec(categorize_backends([backend()]) -> [{family(), [backend()]}]).
 categorize_backends(BEs) ->
-    lists:foldl(fun ({_AgentIP, {IP, _Port, _Weight}}=BE, Acc) ->
+    lists:foldl(fun (BE, Acc) ->
+        case BE of
+            {_AgentIP, {IP, _Port, _Weight}} ->
+                BE0 = BE;
+            {AgentIP, {IP, Port}} ->
+                BE0 = {AgentIP, {IP, Port, 1}}
+        end,
         Family = dcos_l4lb_app:family(IP),
-        orddict:append(Family, BE, Acc)
+        orddict:append(Family, BE0, Acc)
     end, orddict:new(), BEs).
 
 %%%===================================================================

--- a/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_lashup_vip_listener.erl
@@ -1,6 +1,10 @@
 -module(dcos_l4lb_lashup_vip_listener).
 -behaviour(gen_server).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 -export([
     start_link/0,
     ip2name/1,
@@ -126,6 +130,23 @@ categorize_backends(BEs) ->
         Family = dcos_l4lb_app:family(IP),
         orddict:append(Family, BE0, Acc)
     end, orddict:new(), BEs).
+
+-ifdef(TEST).
+
+-define(BE4, {{2, 3, 4, 5}, {{1, 2, 3, 4}, 80, 1}}).
+-define(BE4OLD, {{3, 4, 5, 6}, {{1, 2, 3, 5}, 80}}).
+-define(BE6, {{2, 3, 4, 5}, {{1, 0, 0, 0, 0, 0, 0, 1}, 80, 1}}).
+-define(BE6OLD, {{3, 4, 5, 6}, {{1, 0, 0, 0, 0, 0, 0, 2}, 80}}).
+
+categorize_backends_test() ->
+    ?assertEqual(
+       [{inet, [{{2, 3, 4, 5}, {{1, 2, 3, 4}, 80, 1}},
+                {{3, 4, 5, 6}, {{1, 2, 3, 5}, 80, 1}}]},
+        {inet6, [{{2, 3, 4, 5}, {{1, 0, 0, 0, 0, 0, 0, 1}, 80, 1}},
+                 {{3, 4, 5, 6}, {{1, 0, 0, 0, 0, 0, 0, 2}, 80, 1}}]}],
+       categorize_backends([?BE4, ?BE4OLD, ?BE6, ?BE6OLD])).
+
+-endif.
 
 %%%===================================================================
 %%% Mapping functions

--- a/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
@@ -136,6 +136,11 @@ is_healthy(_TaskId, Task) ->
 -spec(is_healthy(task()) -> boolean()).
 is_healthy(#{healthy := IsHealthy, state := running}) ->
     IsHealthy;
+% NOTE(jkoelker): when the state is `killing` we specifically ignore health
+%                 checks, since mesos stops checking when the task transitions
+%                 to `killing`.
+is_healthy(#{state := killing}) ->
+    true;
 is_healthy(#{state := running}) ->
     true;
 is_healthy(_Task) ->

--- a/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
@@ -358,8 +358,8 @@ init_metrics() ->
         {help, "The number of local tasks."}]),
     prometheus_gauge:new([
         {registry, l4lb},
-        {name, local_healthy_tasks},
-        {help, "The number of local healthy tasks."}]),
+        {name, local_running_tasks},
+        {help, "The number of local running tasks."}]),
     prometheus_gauge:new([
         {registry, l4lb},
         {name, local_backends},

--- a/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
@@ -21,7 +21,7 @@
     handle_cast/2, handle_info/2, handle_continue/2]).
 
 -export_type([named_vip/0, vip/0, protocol/0,
-    key/0, lkey/0, backend/0]).
+    key/0, lkey/0, backend/0, backend_weight/0]).
 
 -record(state, {
     backoff :: backoff:backoff(),
@@ -39,8 +39,11 @@
 -type lkey() :: {key(), riak_dt_orswot}.
 -type backend() :: {
     AgentIP :: inet:ip4_address(),
-    {BackendIP :: inet:ip_address(), BackendPort :: inet:port_number() }
+    {BackendIP :: inet:ip_address(),
+     BackendPort :: inet:port_number(),
+     BackendWeight :: backend_weight() }
 }.
+-type backend_weight() :: 0..65535.
 
 -spec(start_link() ->
     {ok, Pid :: pid()} | ignore | {error, Reason :: term()}).
@@ -210,15 +213,24 @@ key(Task, PortObj, VIPLabel) ->
 backends(Key, Task, PortObj) ->
     IsIPv6Enabled = dcos_l4lb_config:ipv6_enabled(),
     AgentIP = maps:get(agent_ip, Task),
+    Weight = get_weight(Task),
     case maps:find(host_port, PortObj) of
         error ->
             Port = maps:get(port, PortObj),
-            [ {AgentIP, {TaskIP, Port}}
+            [ {AgentIP, {TaskIP, Port, Weight}}
             || TaskIP <- maps:get(task_ip, Task),
                validate_backend_ip(IsIPv6Enabled, Key, TaskIP) ];
         {ok, HostPort} ->
-            [{AgentIP, {AgentIP, HostPort}}]
+            [{AgentIP, {AgentIP, HostPort, Weight}}]
     end.
+
+-spec(get_weight(task()) -> backend_weight()).
+get_weight(#{state := killing}) ->
+    0;
+get_weight(#{state := running}) ->
+    1;
+get_weight(_Task) ->
+    0.
 
 -spec(validate_backend_ip(boolean(), key(), inet:ip_address()) -> boolean()).
 validate_backend_ip(true, {_Protocol, {name, _Name}, _VIPPort}, _TaskIP) ->

--- a/apps/dcos_l4lb/src/dcos_l4lb_mgr.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mgr.erl
@@ -801,6 +801,20 @@ init_unreachable_metrics() ->
 
 -ifdef(TEST).
 
+-define(BE4, {{1, 2, 3, 4}, 80, 1}).
+-define(BE4OLD, {{1, 2, 3, 5}, 80}).
+
+be_port_mapping_test() ->
+    PMs = #{{tcp, 8080} => {{1, 2, 3, 5}, 80},
+            {udp, 8181} => {{1, 0, 0, 0, 0, 0, 0, 2}, 80}},
+    AgentIP = {2, 3, 4, 5},
+    ?assertEqual(
+       {{2, 3, 4, 5}, {{1, 2, 3, 4}, 80, 1}},
+       be_port_mapping(PMs, tcp, AgentIP, AgentIP, ?BE4)),
+    ?assertEqual(
+       {{2, 3, 4, 5}, {{1, 2, 3, 5}, 80, 1}},
+       be_port_mapping(PMs, tcp, AgentIP, AgentIP, ?BE4OLD)).
+
 diff_simple_test() ->
     ?assertEqual(
         {[], [], []},

--- a/apps/dcos_l4lb/test/dcos_l4lb_ipvs_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_ipvs_SUITE.erl
@@ -90,7 +90,7 @@ webserver(Pid, AgentIP) ->
     Info = httpd:info(Pid),
     Port = proplists:get_value(port, Info),
     IP = proplists:get_value(bind_address, Info),
-    {AgentIP, {IP, Port}}.
+    {AgentIP, {IP, Port, 1}}.
 
 add_webserver(VIP, WebServer) ->
     % inject an update for this vip

--- a/apps/dcos_l4lb/test/dcos_l4lb_lashup_vip_listener_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_lashup_vip_listener_SUITE.erl
@@ -47,8 +47,8 @@ end_per_testcase(_, _Config) ->
 
 -define(LKEY(K), {{tcp, K, 80}, riak_dt_orswot}).
 -define(LKEY(L, F), ?LKEY({name, {L, F}})).
--define(BE4, {{1, 2, 3, 4}, {{1, 2, 3, 4}, 80}}).
--define(BE6, {{1, 2, 3, 4}, {{1, 0, 0, 0, 0, 0, 0, 1}, 80}}).
+-define(BE4, {{1, 2, 3, 4}, {{1, 2, 3, 4}, 80, 1}}).
+-define(BE6, {{1, 2, 3, 4}, {{1, 0, 0, 0, 0, 0, 0, 1}, 80, 1}}).
 
 lookup_vips(_Config) ->
     lashup_kv:request_op(?VIPS_KEY2, {update, [

--- a/apps/dcos_l4lb/test/dcos_l4lb_lashup_vip_listener_SUITE.erl
+++ b/apps/dcos_l4lb/test/dcos_l4lb_lashup_vip_listener_SUITE.erl
@@ -48,11 +48,13 @@ end_per_testcase(_, _Config) ->
 -define(LKEY(K), {{tcp, K, 80}, riak_dt_orswot}).
 -define(LKEY(L, F), ?LKEY({name, {L, F}})).
 -define(BE4, {{1, 2, 3, 4}, {{1, 2, 3, 4}, 80, 1}}).
+-define(BE4OLD, {{1, 2, 3, 5}, {{1, 2, 3, 5}, 80}}).
 -define(BE6, {{1, 2, 3, 4}, {{1, 0, 0, 0, 0, 0, 0, 1}, 80, 1}}).
 
 lookup_vips(_Config) ->
     lashup_kv:request_op(?VIPS_KEY2, {update, [
         {update, ?LKEY({1, 2, 3, 4}), {add, ?BE4}},
+        {update, ?LKEY({1, 2, 3, 5}), {add, ?BE4OLD}},
         {update, ?LKEY(<<"/foo">>, <<"bar">>), {add, ?BE4}},
         {update, ?LKEY(<<"/baz">>, <<"qux">>), {add, ?BE4}},
         {update, ?LKEY(<<"/qux">>, <<"ipv6">>), {add, ?BE6}}
@@ -73,6 +75,7 @@ lookup_vips(_Config) ->
 
     lashup_kv:request_op(?VIPS_KEY2, {update, [
         {update, ?LKEY({1, 2, 3, 4}), {remove, ?BE4}},
+        {update, ?LKEY({1, 2, 3, 5}), {remove, ?BE4OLD}},
         {update, ?LKEY(<<"/baz">>, <<"qux">>), {remove, ?BE4}},
         {update, ?LKEY(<<"/qux">>, <<"ipv6">>), {remove, ?BE6}}
     ]}),

--- a/apps/dcos_net/src/dcos_net_mesos_listener.erl
+++ b/apps/dcos_net/src/dcos_net_mesos_listener.erl
@@ -32,7 +32,7 @@
     ports => [task_port()]
 }.
 -type runtime() :: docker | mesos | unknown.
--type task_state() :: preparing | running | terminal.
+-type task_state() :: preparing | running | killing | terminal.
 -type task_port() :: #{
     name => binary(),
     host_port => inet:port_number(),
@@ -536,6 +536,8 @@ handle_task_state(TaskObj, _Task) ->
             terminal;
         <<"TASK_RUNNING">> ->
             running;
+        <<"TASK_KILLING">> ->
+            killing;
         _TaskState ->
             preparing
     end.

--- a/apps/dcos_rest/src/dcos_rest_vips_handler.erl
+++ b/apps/dcos_rest/src/dcos_rest_vips_handler.erl
@@ -51,7 +51,7 @@ vip(Protocol, FullName, Port) ->
     PortBin = integer_to_binary(Port),
     {<<FullName/binary, ":", PortBin/binary>>, Protocol}.
 
-backend({_AgentIP, {IP, Port}}) ->
+backend({_AgentIP, {IP, Port, _Weight}}) ->
     #{
         ip => ip(IP),
         port => Port

--- a/rebar.config
+++ b/rebar.config
@@ -182,7 +182,7 @@
         rules => [
             {elvis_style, max_function_length, #{max_length => 30}},
             {elvis_style, no_spec_with_records},
-            {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
+            {elvis_style, dont_repeat_yourself, #{min_complexity => 21}},
             {elvis_style, no_behavior_info},
             {elvis_style, used_ignored_variable},
             {elvis_style, nesting_level, #{level => 3}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -17,7 +17,7 @@
  {<<"folsom">>,{pkg,<<"folsom">>,<<"0.8.8">>},0},
  {<<"gen_netlink">>,
   {git,"https://github.com/mesosphere/gen_netlink.git",
-       {ref,"3d8d268a54af13a91246d5b3438b1facf29f77a9"}},
+       {ref,"99948ccc687212687c3757f2852fd197923ba20d"}},
   0},
  {<<"inotify">>,
   {git,"https://github.com/dcos/inotify.git",


### PR DESCRIPTION
JIRA: https://jira.d2iq.com/browse/COPS-6002
DCOS PR: https://github.com/dcos/dcos/pull/7185

---
↩️  _This PR back-ports a fix introduced with #193 to 2.0.x._

---

Set the weight to 0 for unhealthy tasks and tasks entering `TASK_KILLING`. This allows existing connections to gracefully terminate while not accepting new connections to a backend.