### PR TITLE
l4lb: fix metric name

### DIFF
--- a/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
+++ b/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl
@@ -358,8 +358,8 @@ init_metrics() ->
         {help, "The number of local tasks."}]),
     prometheus_gauge:new([
         {registry, l4lb},
-        {name, local_healthy_tasks},
-        {help, "The number of local healthy tasks."}]),
+        {name, local_running_tasks},
+        {help, "The number of local running tasks."}]),
     prometheus_gauge:new([
         {registry, l4lb},
         {name, local_backends},


### PR DESCRIPTION
Fixes a crash in the metrics exporter introduced with the `TASK_KILLING` refactor:

```
Mar 24 18:00:39 ip-172-16-16-122.us-west-2.compute.internal dcos-net-env[12452]: 2020-03-24T18:00:39.237727+00:00 [error] <0.19796.6>@gen_server:error_info/7:889: ** Generic server dcos_l4lb_mesos_poller terminating , ** Last message in was {continue,poll}, ** When Server state == {state,{backoff,2000,60000,2000,jitter,poll,<0.19796.6>},#Ref<0.3870889881.2482503682.72417>}, ** Reason for termination ==, ** {{unknown_metric,l4lb,local_running_tasks},[{prometheus_metric,check_mf_exists,4,[{file,"/pkg/src/dcos-net/_build/default/lib/prometheus/src/prometheus_metric.erl"},{line,142}]},{prometheus_gauge,insert_metric,5,[{file,"/pkg/src/dcos-net/_build/default/lib/prometheus/src/metrics/prometheus_gauge.erl"},{line,475}]},{dcos_l4lb_mesos_poller,handle_poll_state,1,[{file,"/pkg/src/dcos-net/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl"},{line,131}]},{dcos_l4lb_mesos_poller,handle_poll,2,[{file,"/pkg/src/dcos-net/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl"},{line,108}]},{dcos_l4lb_mesos_poller,handle_continue,2,[{file,"/pkg/src/dcos-net/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl"},{line,79}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,637}]},{gen_server,loop,7,[{file,"gen_server.erl"},{line,388}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}
Mar 24 18:00:39 ip-172-16-16-122.us-west-2.compute.internal dcos-net-env[12452]: 2020-03-24T18:00:39.238225+00:00 [error] <0.19796.6>@proc_lib:crash_report/4:508: crasher: initial call: dcos_l4lb_mesos_poller:init/1, pid: <0.19796.6>, registered_name: dcos_l4lb_mesos_poller, error: {{unknown_metric,l4lb,local_running_tasks},[{prometheus_metric,check_mf_exists,4,[{file,"/pkg/src/dcos-net/_build/default/lib/prometheus/src/prometheus_metric.erl"},{line,142}]},{prometheus_gauge,insert_metric,5,[{file,"/pkg/src/dcos-net/_build/default/lib/prometheus/src/metrics/prometheus_gauge.erl"},{line,475}]},{dcos_l4lb_mesos_poller,handle_poll_state,1,[{file,"/pkg/src/dcos-net/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl"},{line,131}]},{dcos_l4lb_mesos_poller,handle_poll,2,[{file,"/pkg/src/dcos-net/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl"},{line,108}]},{dcos_l4lb_mesos_poller,handle_continue,2,[{file,"/pkg/src/dcos-net/apps/dcos_l4lb/src/dcos_l4lb_mesos_poller.erl"},{line,79}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,637}]},{gen_server,loop,7,[{file,"gen_server.erl"},{line,388}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}, ancestors: [dcos_l4lb_sup,<0.1540.0>], message_queue_len: 0, messages: [], links: [<0.1545.0>], dictionary: [], trap_exit: false, status: running, heap_size: 10958, stack_size: 27, reductions: 52805; neighbours:
```