### PR TITLE
rest: extract elements instead of matching

### DIFF
--- a/apps/dcos_rest/src/dcos_rest_vips_handler.erl
+++ b/apps/dcos_rest/src/dcos_rest_vips_handler.erl
@@ -51,10 +51,10 @@ vip(Protocol, FullName, Port) ->
     PortBin = integer_to_binary(Port),
     {<<FullName/binary, ":", PortBin/binary>>, Protocol}.
 
-backend({_AgentIP, {IP, Port, _Weight}}) ->
+backend({_AgentIP, BE}) ->
     #{
-        ip => ip(IP),
-        port => Port
+        ip => ip(element(1, BE)),
+        port => element(2, BE)
     }.
 
 ip(IP) ->


### PR DESCRIPTION
If the host has old style VIPs, then the matching will fail, instead
just extract the first two elements regardless of the length.

https://github.com/dcos/dcos/pull/7568